### PR TITLE
Bugfix/leeap 4954 wardrobe 出荷準備中のアイテムでは出荷準備に移動ボタンを押せないようにする

### DIFF
--- a/src/components/rentals/RentalConfirm.tsx
+++ b/src/components/rentals/RentalConfirm.tsx
@@ -13,6 +13,7 @@ import {
 import { useContext, useState } from "react";
 import { useQueryClient } from "react-query";
 import { useLocation } from "react-router-dom";
+import { CREATING_COORDINATE } from "../../constants/rentalStatus";
 import { TRentalCoordinateShowResponse } from "../../hooks/api/UseRentalCoordinateShow";
 import { useRentalCoordinateUpdate } from "../../hooks/api/UseRentalCoordinateUpdate";
 import { useRentalRequestShow } from "../../hooks/api/UseRentalRequestShow";
@@ -28,7 +29,6 @@ export const RentalConfirm = ({
   rentalCoordinate,
   onClickBackButton,
 }: TProps) => {
-  const CREATING_COORDINATE = 10;
   const search = useLocation().search;
   const { rentalId } = useContext(RentalIdContext);
   const queryClient = useQueryClient();

--- a/src/components/rentals/RentalConfirm.tsx
+++ b/src/components/rentals/RentalConfirm.tsx
@@ -42,6 +42,10 @@ export const RentalConfirm = ({
   const [selectedCoordinateChoiceId, setSelectedCoordinateChoiceId] =
     useState<number>(rentalCoordinate.coordinateChoiceId);
 
+  const isNotYetAllPicked = rentalCoordinate.items.some(
+    (item) => item.locationId !== null,
+  );
+
   if (rentalRequestError)
     return <Typography>{rentalRequestError.message}</Typography>;
 
@@ -79,7 +83,7 @@ export const RentalConfirm = ({
             disabled={
               isUpdateShipmentStatusLoading ||
               rentalCoordinate.items.length !== 3 ||
-              rentalCoordinate.items.some((item) => item.locationId !== null)
+              isNotYetAllPicked
             }
             onClick={() => {
               if (window.confirm("出荷準備に移動しますか？")) {

--- a/src/components/rentals/RentalConfirm.tsx
+++ b/src/components/rentals/RentalConfirm.tsx
@@ -12,6 +12,7 @@ import {
 } from "@mui/material";
 import { useContext, useState } from "react";
 import { useQueryClient } from "react-query";
+import { useLocation } from "react-router-dom";
 import { TRentalCoordinateShowResponse } from "../../hooks/api/UseRentalCoordinateShow";
 import { useRentalCoordinateUpdate } from "../../hooks/api/UseRentalCoordinateUpdate";
 import { useRentalRequestShow } from "../../hooks/api/UseRentalRequestShow";
@@ -27,6 +28,8 @@ export const RentalConfirm = ({
   rentalCoordinate,
   onClickBackButton,
 }: TProps) => {
+  const CREATING_COORDINATE = 10;
+  const search = useLocation().search;
   const { rentalId } = useContext(RentalIdContext);
   const queryClient = useQueryClient();
   const {
@@ -41,6 +44,10 @@ export const RentalConfirm = ({
     useRentalRequestShow({ rentalId });
   const [selectedCoordinateChoiceId, setSelectedCoordinateChoiceId] =
     useState<number>(rentalCoordinate.coordinateChoiceId);
+
+  const statusQuery = new URLSearchParams(search);
+  const isRentalStatusCreatingCoordinate =
+    parseInt(statusQuery.get("status") ?? "") === CREATING_COORDINATE;
 
   const isNotYetAllPicked = rentalCoordinate.items.some(
     (item) => item.locationId !== null,
@@ -83,10 +90,14 @@ export const RentalConfirm = ({
             disabled={
               isUpdateShipmentStatusLoading ||
               rentalCoordinate.items.length !== 3 ||
-              isNotYetAllPicked
+              isNotYetAllPicked ||
+              !isRentalStatusCreatingCoordinate
             }
             onClick={() => {
-              if (window.confirm("出荷準備に移動しますか？")) {
+              if (
+                isRentalStatusCreatingCoordinate &&
+                window.confirm("出荷準備に移動しますか？")
+              ) {
                 updateStatus(undefined, {
                   onSuccess: () => {
                     alert("登録しました");

--- a/src/constants/rentalStatus.ts
+++ b/src/constants/rentalStatus.ts
@@ -1,0 +1,1 @@
+export const CREATING_COORDINATE = 10;


### PR DESCRIPTION

https://github.com/KiizanKiizan/wardrobe/assets/105505578/6a95d0d8-31d9-4e1c-b1e2-4349d87dbd77

確認お願いします！

https://kiizankiizan.sentry.io/issues/4569567901/?alert_rule_id=10864668&alert_type=issue&notification_uuid=a14955b3-db1f-42c4-89d0-a7a7182bad63&project=6327400&referrer=slack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

新機能:
- レンタルステータスが「座標作成中」の場合に確認ダイアログを表示する機能を追加しました。これにより、ユーザーはレンタルプロセスの特定のステージでのアクションを確認できます。

改善:
- ボタンの無効化条件が改善され、全てのアイテムが選択されていない場合にボタンが無効化されます。これにより、ユーザーは必要なすべてのアイテムを選択するまで次のステップに進むことができません。

これらの変更により、ユーザーはレンタルプロセスをより明確に理解し、適切なアクションを選択することができます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->