### PR TITLE
LEEAP-4975 prettierルールを統一する

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "react-app",
-      "react-app/jest"
+      "@kiizan_kiizan/eslint-config"
     ]
   },
   "browserslist": {
@@ -71,7 +70,10 @@
     ]
   },
   "devDependencies": {
+    "@kiizan_kiizan/eslint-config": "^0.0.7",
+    "@kiizan_kiizan/prettier-config": "^0.0.5",
     "@sentry/webpack-plugin": "^2.7.1",
     "husky": "^8.0.2"
-  }
+  },
+  "prettier": "@kiizan_kiizan/prettier-config"
 }

--- a/src/components/chart/Chart.tsx
+++ b/src/components/chart/Chart.tsx
@@ -14,9 +14,7 @@ export const Chart = ({ id, rentalStartedAt }: TProps) => {
           <Typography variant="h6">カルテID: {id}</Typography>
           <Typography variant="body2" style={{ color: "gray" }}>
             発送日:
-            {rentalStartedAt
-              ? new Date(rentalStartedAt!).toLocaleDateString()
-              : ""}
+            {rentalStartedAt ? new Date(rentalStartedAt!).toLocaleDateString() : ""}
           </Typography>
         </ListItemText>
       </ListItem>

--- a/src/components/chart/createCoordinateFlexMessage.ts
+++ b/src/components/chart/createCoordinateFlexMessage.ts
@@ -12,7 +12,7 @@ export const createCoordinateFlexMessage = ({
   coordinateItems,
   simplifiedHearing,
 }: TArgs) => {
-  const flexMessage: any[] = [];
+  const flexMessage: object[] = [];
 
   const simplifiedHearingContent = {
     type: "bubble",

--- a/src/components/coordinateDescription/CoordinateDescription.tsx
+++ b/src/components/coordinateDescription/CoordinateDescription.tsx
@@ -15,8 +15,8 @@ type TProps = {
   readonly coordinateId: number;
   readonly coordinateItems: TCoordinateItem[];
   readonly isLineMessagesSendDisable: boolean;
-  readonly onUpdateComplete: () => Promise<any>;
-  readonly hearingStatusData: TCoordinateHearingStatusShowResponse | {};
+  readonly onUpdateComplete: () => Promise<unknown>;
+  readonly hearingStatusData: TCoordinateHearingStatusShowResponse | object;
 };
 
 export const CoordinateDescription = ({

--- a/src/components/coordinateDescription/CoordinateDescriptionLineSendButton.tsx
+++ b/src/components/coordinateDescription/CoordinateDescriptionLineSendButton.tsx
@@ -1,12 +1,4 @@
-import {
-  Alert,
-  Box,
-  Button,
-  CircularProgress,
-  Dialog,
-  Snackbar,
-  Typography,
-} from "@mui/material";
+import { Alert, Box, Button, CircularProgress, Dialog, Snackbar, Typography } from "@mui/material";
 import { useState } from "react";
 import { useQueryClient } from "react-query";
 import { useCoordinateHearingStatusShow } from "../../hooks/api/UseCoordinateHearingStatusShow";
@@ -43,11 +35,10 @@ export const CoordinateDescriptionLineSendButton = ({
   const [severity, setSeverity] = useState<"success" | "error">("success");
   const [snackBarText, setSnackBarText] = useState("");
   const { mutate, isLoading } = useLineMessagesCreate();
-  const { mutate: mutateStatus } =
-    useCoordinateHearingStatusUpdate(coordinateId);
+  const { mutate: mutateStatus } = useCoordinateHearingStatusUpdate(coordinateId);
   const { data, error } = useCoordinateHearingStatusShow({ coordinateId });
 
-  const onUnload = (e: any) => {
+  const onUnload = (e: BeforeUnloadEvent) => {
     e.preventDefault();
     e.returnValue = "";
   };

--- a/src/components/coordinateFomalRank/CoordinateFormalRanks.tsx
+++ b/src/components/coordinateFomalRank/CoordinateFormalRanks.tsx
@@ -6,17 +6,11 @@ import { CoordinateFormalRanksShowResponse } from "../../model/api/response/styl
 type TProps = {
   coordinateId: number;
   response: CoordinateFormalRanksShowResponse;
-  onUpdateComplete: () => Promise<any>;
+  onUpdateComplete: () => Promise<unknown>;
 };
 
-export const CoordinateFormalRanks = ({
-  coordinateId,
-  response,
-  onUpdateComplete,
-}: TProps) => {
-  const [formalRank, setFormalRank] = useState<number>(
-    response.formalRank || 0
-  );
+export const CoordinateFormalRanks = ({ coordinateId, response, onUpdateComplete }: TProps) => {
+  const [formalRank, setFormalRank] = useState<number>(response.formalRank || 0);
   const [isSnackBarOpen, setIsSnackBarOpen] = useState(false);
   const [severity, setSeverity] = useState<"success" | "error">("success");
   const [snackBarText, setSnackBarText] = useState("");

--- a/src/components/coordinateMemo/CoordinateMemo.tsx
+++ b/src/components/coordinateMemo/CoordinateMemo.tsx
@@ -8,14 +8,10 @@ import { MemoForm } from "../shared/MemoForm";
 type TProps = {
   readonly coordinateId: number;
   readonly response: CoordinateMemosShowResponse;
-  readonly onUpdateComplete: () => Promise<any>;
+  readonly onUpdateComplete: () => Promise<unknown>;
 };
 
-export const CoordinateMemo = ({
-  coordinateId,
-  response,
-  onUpdateComplete,
-}: TProps) => {
+export const CoordinateMemo = ({ coordinateId, response, onUpdateComplete }: TProps) => {
   const [memo, setMemo] = useState(response.memo);
   const [isSnackBarOpen, setIsSnackBarOpen] = useState(false);
   const [severity, setSeverity] = useState<"success" | "error">("success");
@@ -51,7 +47,7 @@ export const CoordinateMemo = ({
               onSettled: () => {
                 setIsSnackBarOpen(true);
               },
-            }
+            },
           );
         }}
       />

--- a/src/components/coordinateStylistComment/CoordinateStylistComment.tsx
+++ b/src/components/coordinateStylistComment/CoordinateStylistComment.tsx
@@ -8,14 +8,10 @@ import { MemoForm } from "../shared/MemoForm";
 type TProps = {
   data: CoordinateStylistCommentsShowResponse;
   coordinateId: number;
-  onUpdateComplete: () => Promise<any>;
+  onUpdateComplete: () => Promise<unknown>;
 };
 
-export const CoordinateStylistComment = ({
-  data,
-  coordinateId,
-  onUpdateComplete,
-}: TProps) => {
+export const CoordinateStylistComment = ({ data, coordinateId, onUpdateComplete }: TProps) => {
   const [text, setText] = useState(data.text ?? "");
   const { mutate, isLoading } = useCoordinateStylistCommentsUpdate({
     coordinateId,
@@ -40,7 +36,7 @@ export const CoordinateStylistComment = ({
         onSettled: () => {
           setIsSnackBarOpen(true);
         },
-      }
+      },
     );
   };
 

--- a/src/components/coordinateTopsRatio.tsx/CoordinateTopsRatio.tsx
+++ b/src/components/coordinateTopsRatio.tsx/CoordinateTopsRatio.tsx
@@ -16,23 +16,15 @@ import { alertClosedWindow } from "../../service/shared/alertClosedWindow";
 type TProps = {
   readonly coordinateId: number;
   readonly response: CoordinateTopsRatiosShowResponse;
-  readonly onUpdateComplete: () => Promise<any>;
+  readonly onUpdateComplete: () => Promise<unknown>;
 };
 
-export const CoordinateTopsRatio = ({
-  coordinateId,
-  response,
-  onUpdateComplete,
-}: TProps) => {
+export const CoordinateTopsRatio = ({ coordinateId, response, onUpdateComplete }: TProps) => {
   const [isJacketRequested, setIsJacketRequested] = useState(
-    response.jacketOption?.isJacketRequested
+    response.jacketOption?.isJacketRequested,
   );
-  const [shortSleeveNum, setShortSleeveNum] = useState<number>(
-    response.shortSleeveNum || 0
-  );
-  const [longSleeveNum, setLongSleeveNum] = useState<number>(
-    response.longSleeveNum || 0
-  );
+  const [shortSleeveNum, setShortSleeveNum] = useState<number>(response.shortSleeveNum || 0);
+  const [longSleeveNum, setLongSleeveNum] = useState<number>(response.longSleeveNum || 0);
   const { mutate, isLoading } = useCoordinateTopsRatiosUpdate({
     coordinateId,
     longSleeveNum: longSleeveNum,
@@ -45,8 +37,7 @@ export const CoordinateTopsRatio = ({
   const isFirstRendering = useRef(false);
 
   const isChanged =
-    shortSleeveNum !== response.shortSleeveNum ||
-    longSleeveNum !== response.longSleeveNum;
+    shortSleeveNum !== response.shortSleeveNum || longSleeveNum !== response.longSleeveNum;
   const validateTopsNum = () => {
     if (shortSleeveNum < 0 || longSleeveNum < 0) return false;
     if (response.topsNum === null) return true;
@@ -76,7 +67,7 @@ export const CoordinateTopsRatio = ({
         },
       });
     },
-    [mutate, onUpdateComplete]
+    [mutate, onUpdateComplete],
   );
 
   useEffect(() => {

--- a/src/components/member/style/UseMemberImageCollectionDialogStyle.ts
+++ b/src/components/member/style/UseMemberImageCollectionDialogStyle.ts
@@ -1,9 +1,7 @@
-import { Theme } from "@mui/material/styles";
-
 import createStyles from "@mui/styles/createStyles";
 import makeStyles from "@mui/styles/makeStyles";
 
-export const useMemberImageCollectionDialogStyle = makeStyles((theme: Theme) =>
+export const useMemberImageCollectionDialogStyle = makeStyles(() =>
   createStyles({
     imageGallery: {
       "& .image-gallery-thumbnails": {
@@ -13,5 +11,5 @@ export const useMemberImageCollectionDialogStyle = makeStyles((theme: Theme) =>
         transform: "none !important",
       },
     },
-  })
+  }),
 );

--- a/src/components/memberSize/input/MemberSizeNumberInput.tsx
+++ b/src/components/memberSize/input/MemberSizeNumberInput.tsx
@@ -28,7 +28,7 @@ export const MemberSizeNumberInput = ({
     const v = e.target.value;
     if (v === "") return onChange(null);
 
-    const isNumber = (arg: any): arg is number => {
+    const isNumber = (arg: unknown): arg is number => {
       return !Number.isNaN(arg);
     };
 

--- a/src/components/rentals/FilterList.tsx
+++ b/src/components/rentals/FilterList.tsx
@@ -22,9 +22,7 @@ export const FilterList = ({
   onItemSelect,
   currentItemId,
 }: TProps) => {
-  const [currentRefinement, setCurrentRefinement] = useState<Refinement>(
-    filter.defaultRefinement,
-  );
+  const [currentRefinement, setCurrentRefinement] = useState<Refinement>(filter.defaultRefinement);
 
   const handleChangeCurrentRefinement = (refinement: Refinement) => {
     setCurrentRefinement(refinement);

--- a/src/components/rentals/RentalConfirm.tsx
+++ b/src/components/rentals/RentalConfirm.tsx
@@ -23,27 +23,21 @@ type TProps = {
   rentalCoordinate: TRentalCoordinateShowResponse;
   onClickBackButton: () => void;
 };
-export const RentalConfirm = ({
-  rentalCoordinate,
-  onClickBackButton,
-}: TProps) => {
+export const RentalConfirm = ({ rentalCoordinate, onClickBackButton }: TProps) => {
   const { rentalId } = useContext(RentalIdContext);
   const queryClient = useQueryClient();
-  const {
-    mutate: updateCoordinateChoice,
-    isLoading: isUpdateCoordinateLoading,
-  } = useRentalCoordinateUpdate({
-    rentalId,
-  });
+  const { mutate: updateCoordinateChoice, isLoading: isUpdateCoordinateLoading } =
+    useRentalCoordinateUpdate({
+      rentalId,
+    });
   const { mutate: updateStatus, isLoading: isUpdateShipmentStatusLoading } =
     useRentalUpdateToPreparingShipment({ rentalId });
-  const { data: rentalRequest, error: rentalRequestError } =
-    useRentalRequestShow({ rentalId });
-  const [selectedCoordinateChoiceId, setSelectedCoordinateChoiceId] =
-    useState<number>(rentalCoordinate.coordinateChoiceId);
+  const { data: rentalRequest, error: rentalRequestError } = useRentalRequestShow({ rentalId });
+  const [selectedCoordinateChoiceId, setSelectedCoordinateChoiceId] = useState<number>(
+    rentalCoordinate.coordinateChoiceId,
+  );
 
-  if (rentalRequestError)
-    return <Typography>{rentalRequestError.message}</Typography>;
+  if (rentalRequestError) return <Typography>{rentalRequestError.message}</Typography>;
 
   if (!rentalRequest) return <CircularProgress />;
 
@@ -87,7 +81,8 @@ export const RentalConfirm = ({
                   onSuccess: () => {
                     alert("登録しました");
                   },
-                  onError: (error) => {
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  onError: (error: any) => {
                     alert(error.message);
                   },
                 });
@@ -138,11 +133,10 @@ export const RentalConfirm = ({
                 {
                   onSuccess: () => {
                     alert("更新しました");
-                    queryClient.invalidateQueries(
-                      `biz/rentals/${rentalId}/rental_coordinate`,
-                    );
+                    queryClient.invalidateQueries(`biz/rentals/${rentalId}/rental_coordinate`);
                   },
-                  onError: (error) => {
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  onError: (error: any) => {
                     alert(error.message);
                   },
                 },
@@ -159,8 +153,8 @@ export const RentalConfirm = ({
             marginTop: 50,
           }}
         >
-          {rentalCoordinate.items.map((item, index) => (
-            <ItemConfirmCard item={item} />
+          {rentalCoordinate.items.map((item) => (
+            <ItemConfirmCard item={item} key={item.id} />
           ))}
         </div>
       </div>

--- a/src/components/rentals/RentalFilterGroupCollection.tsx
+++ b/src/components/rentals/RentalFilterGroupCollection.tsx
@@ -21,10 +21,7 @@ type TProps = {
   filterCollection: TRentalFilterGroupCollectionData;
   callback: TRentalFilterGroupCollectionCallback;
 };
-export const RentalFilterGroupCollection = ({
-  filterCollection,
-  callback,
-}: TProps) => {
+export const RentalFilterGroupCollection = ({ filterCollection, callback }: TProps) => {
   const classes = useFilterGroupCollectionStyle();
   return (
     <div className={classes.filterPaper}>
@@ -54,10 +51,7 @@ export const RentalFilterGroupCollection = ({
           <Typography variant="body2">サイズ</Typography>
         </AccordionSummary>
         <AccordionDetails>
-          <FilterSizeArray
-            data={filterCollection.sizeData}
-            callback={callback.sizeCallback}
-          />
+          <FilterSizeArray data={filterCollection.sizeData} callback={callback.sizeCallback} />
         </AccordionDetails>
       </Accordion>
       <Accordion>
@@ -192,6 +186,7 @@ export const RentalFilterGroupCollection = ({
         InputProps={{ startAdornment: <Search /> }}
         color="secondary"
         type="number"
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         onKeyPress={(event: any) => {
           if (event.key === "Enter") {
             callback.onItemIdChanged(event.target.value as number);

--- a/src/components/rentals/RentalItemBrowse.tsx
+++ b/src/components/rentals/RentalItemBrowse.tsx
@@ -23,17 +23,12 @@ export const RentalItemBrowse = ({
   useEffect(() => {
     onChangeTotalCount(browsesIndex?.totalCount ?? 0);
     onChangeTotalPageNum(browsesIndex?.totalPageNum ?? 0);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [browsesIndex]);
 
-  if (browsesIndexError)
-    return <Typography>{browsesIndexError.message}</Typography>;
+  if (browsesIndexError) return <Typography>{browsesIndexError.message}</Typography>;
   if (!browsesIndex) return <CircularProgress />;
 
   return (
-    <RentalItemCardCollection
-      items={browsesIndex.itemCard}
-      onClickItemCard={onClickItemCard}
-    />
+    <RentalItemCardCollection items={browsesIndex.itemCard} onClickItemCard={onClickItemCard} />
   );
 };

--- a/src/components/rentals/RentalItemBrowseContainer.tsx
+++ b/src/components/rentals/RentalItemBrowseContainer.tsx
@@ -1,10 +1,4 @@
-import {
-  FormControl,
-  Pagination,
-  Select,
-  Toolbar,
-  Typography,
-} from "@mui/material";
+import { FormControl, Pagination, Select, Toolbar, Typography } from "@mui/material";
 import { useState } from "react";
 import { TRentalFiltersResponse } from "../../hooks/api/UseRentalFilters";
 import { Refinement } from "../../model/selecting/browse/Refinement";
@@ -33,22 +27,19 @@ export const RentalItemBrowseContainer = ({
 
   const [totalCount, setTotalCount] = useState<number>(0);
   const [totalPageNum, setTotalPageNum] = useState<number>(0);
-  const { appliedFilterArrayData, handleClickDelete, handleClickClear } =
-    getFilterListHandler({
-      filter: filter.filter,
-      currentRefinement,
-      defaultRefinement: filter.defaultRefinement,
-      sort: filter.sort,
-      categoryId,
-      onChangeCurrentRefinement,
-    });
+  const { appliedFilterArrayData, handleClickDelete, handleClickClear } = getFilterListHandler({
+    filter: filter.filter,
+    currentRefinement,
+    defaultRefinement: filter.defaultRefinement,
+    categoryId,
+    onChangeCurrentRefinement,
+  });
 
-  const { filterCollection, filterCollectionCallback } =
-    getFilterGroupCollectionHandler({
-      filter: filter.filter,
-      currentRefinement,
-      onChangeCurrentRefinement,
-    });
+  const { filterCollection, filterCollectionCallback } = getFilterGroupCollectionHandler({
+    filter: filter.filter,
+    currentRefinement,
+    onChangeCurrentRefinement,
+  });
 
   const onPageChanged = (page: number) => {
     onChangeCurrentRefinement({
@@ -83,11 +74,7 @@ export const RentalItemBrowseContainer = ({
           <FormControl className={classes.sortSelection}>
             <Select
               native
-              value={
-                filter.sort.findIndex(
-                  (sort) => sort.id === currentRefinement.sortId,
-                ) ?? 0
-              }
+              value={filter.sort.findIndex((sort) => sort.id === currentRefinement.sortId) ?? 0}
               onChange={(e) => {
                 const index = parseInt(e.target.value as string);
                 const newRefinement = {

--- a/src/components/rentals/RentalItemDetail.tsx
+++ b/src/components/rentals/RentalItemDetail.tsx
@@ -64,7 +64,7 @@ export const RentalItemDetail = ({
     currentItemId,
   });
 
-  let itemImage: itemImageGallery[] = [
+  const itemImage: itemImageGallery[] = [
     {
       originalImagePath: browseDetail.itemImagePath.large,
       thumbnailImagePath: browseDetail.itemImagePath.thumb,
@@ -73,16 +73,14 @@ export const RentalItemDetail = ({
     },
   ];
 
-  let wearingImages: itemImageGallery[] = browseDetail.wearingImages.map(
-    (wearingImage) => {
-      return {
-        originalImagePath: wearingImage.imagePath.large,
-        thumbnailImagePath: wearingImage.imagePath.thumb,
-        itemSize: wearingImage.itemSize,
-        height: wearingImage.height,
-      };
-    },
-  );
+  const wearingImages: itemImageGallery[] = browseDetail.wearingImages.map((wearingImage) => {
+    return {
+      originalImagePath: wearingImage.imagePath.large,
+      thumbnailImagePath: wearingImage.imagePath.thumb,
+      itemSize: wearingImage.itemSize,
+      height: wearingImage.height,
+    };
+  });
 
   return (
     <>
@@ -112,14 +110,8 @@ export const RentalItemDetail = ({
           />
         </div>
         <div className={classes.itemInfoTextContainer}>
-          <Typography
-            className={classes.itemInfoText}
-            variant="h5"
-            color="textSecondary"
-          >
-            {`${browseDetail.seriesName ?? ""}, ${
-              browseDetail.seriesFeature ?? ""
-            }`}
+          <Typography className={classes.itemInfoText} variant="h5" color="textSecondary">
+            {`${browseDetail.seriesName ?? ""}, ${browseDetail.seriesFeature ?? ""}`}
           </Typography>
           <Typography className={classes.itemInfoText} variant="h4">
             {browseDetail.categoryName}
@@ -127,9 +119,7 @@ export const RentalItemDetail = ({
           <Typography className={classes.itemInfoText} variant="h3">
             {browseDetail.brandName}
           </Typography>
-          <Typography variant="body1">
-            メインカラー：{browseDetail.mainColor.name}
-          </Typography>
+          <Typography variant="body1">メインカラー：{browseDetail.mainColor.name}</Typography>
           <div>
             <Box display="flex">
               <img
@@ -141,9 +131,7 @@ export const RentalItemDetail = ({
               />
             </Box>
           </div>
-          <Typography variant="body1">
-            サブカラー：{browseDetail.subColor.name}
-          </Typography>
+          <Typography variant="body1">サブカラー：{browseDetail.subColor.name}</Typography>
           <div>
             <Box display="flex">
               <img
@@ -164,10 +152,7 @@ export const RentalItemDetail = ({
           </div>
           <Typography variant="body1">アイテム：{selectedItemId()}</Typography>
           <div className={classes.itemTableContainer}>
-            <DetailItemTable
-              data={detailItemTableData()}
-              callback={detailItemTableCallback()}
-            />
+            <DetailItemTable data={detailItemTableData()} callback={detailItemTableCallback()} />
           </div>
           <Button
             variant="contained"

--- a/src/components/rentals/RentalItemDetailContainer.tsx
+++ b/src/components/rentals/RentalItemDetailContainer.tsx
@@ -30,8 +30,7 @@ export const RentalItemDetailContainer = ({
     refinement: currentRefinement,
   });
 
-  if (browseDetailError)
-    return <Typography>{browseDetailError.message}</Typography>;
+  if (browseDetailError) return <Typography>{browseDetailError.message}</Typography>;
   if (!browseDetail || isFetching) return <CircularProgress />;
 
   return (

--- a/src/components/rentals/RentalSelecting.tsx
+++ b/src/components/rentals/RentalSelecting.tsx
@@ -19,10 +19,7 @@ type TProps = {
   onClickCompleteButton: () => void;
 };
 
-export const RentalSelecting = ({
-  rentalCoordinateItems,
-  onClickCompleteButton,
-}: TProps) => {
+export const RentalSelecting = ({ rentalCoordinateItems, onClickCompleteButton }: TProps) => {
   const classes = useBrowseStyle();
   const RENTABLE_NUM = 3;
   const { data, error } = useBrowsesSearchPrerequisite();
@@ -32,8 +29,7 @@ export const RentalSelecting = ({
       ? rentalCoordinateItems.length - 1
       : rentalCoordinateItems.length,
   );
-  const [selectedPreregisteredItemId, setSelectedPreregisteredItemId] =
-    useState<number>();
+  const [selectedPreregisteredItemId, setSelectedPreregisteredItemId] = useState<number>();
 
   const currentItemId: number | undefined = rentalCoordinateItems[currentIndex]
     ? rentalCoordinateItems[currentIndex].id

--- a/src/components/rentals/RentalSelectionProgress.tsx
+++ b/src/components/rentals/RentalSelectionProgress.tsx
@@ -35,27 +35,19 @@ export const RentalSelectionProgress = ({
 }: TProps) => {
   const classes = useSelectionProgressStyle();
   const [position, setPosition] = useState<{
-    mouseX: null | Number;
+    mouseX: null | number;
     mouseY: null | number;
   }>(initialState);
 
-  let steps = [];
+  const steps = [];
   for (let i = 0; i < rentableNum; i++) {
     let stepLabel;
     if (items.length > i) {
       stepLabel = (
         <StepLabel
           StepIconComponent={() => (
-            <Box
-              display="flex"
-              border={selectedIndex === i ? 1 : 0}
-              borderColor="primary.main"
-            >
-              <img
-                className={classes.stepperImage}
-                src={items[i].imagePath.thumb}
-                alt=""
-              />
+            <Box display="flex" border={selectedIndex === i ? 1 : 0} borderColor="primary.main">
+              <img className={classes.stepperImage} src={items[i].imagePath.thumb} alt="" />
             </Box>
           )}
         >
@@ -64,9 +56,7 @@ export const RentalSelectionProgress = ({
       );
     } else {
       stepLabel = (
-        <StepLabel>
-          {items.length > i ? items[i].id.toString() : `アイテムNo.${i + 1}`}
-        </StepLabel>
+        <StepLabel>{items.length > i ? items[i].id.toString() : `アイテムNo.${i + 1}`}</StepLabel>
       );
     }
     steps.push(
@@ -87,10 +77,7 @@ export const RentalSelectionProgress = ({
         placement="top-start"
       >
         <Step disabled={items.length < i}>
-          <StepButton
-            className={classes.stepButton}
-            onClick={() => onSelect(i)}
-          >
+          <StepButton className={classes.stepButton} onClick={() => onSelect(i)}>
             {stepLabel}
           </StepButton>
         </Step>
@@ -108,19 +95,11 @@ export const RentalSelectionProgress = ({
         });
       }}
     >
-      <Button
-        variant="contained"
-        color="primary"
-        onClick={onClickCompleteButton}
-      >
+      <Button variant="contained" color="primary" onClick={onClickCompleteButton}>
         アイテム選択完了
       </Button>
       <div style={{ display: "flex" }}>
-        <Stepper
-          activeStep={selectedIndex}
-          alternativeLabel
-          className={classes.stepper}
-        >
+        <Stepper activeStep={selectedIndex} alternativeLabel className={classes.stepper}>
           {steps}
         </Stepper>
         <div style={{ width: 100 }}>

--- a/src/components/rentals/handler/getFilterGroupCollectionHandler.ts
+++ b/src/components/rentals/handler/getFilterGroupCollectionHandler.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-extra-non-null-assertion */
 import { FilterChoiceResponse } from "../../../hooks/api/UseRentalFilters";
 import { LargeCategoryChoiceResponse } from "../../../model/api/response/styling/browse/LargeCategoryChoiceResponse";
 import { FormalRankRefinement } from "../../../model/selecting/browse/FormalRankRefinement";
@@ -21,12 +22,8 @@ export const getFilterGroupCollectionHandler = ({
   onChangeCurrentRefinement,
 }: TArgs) => {
   // 現在の大カテを返す
-  const getCurrentLargeCategory = ():
-    | LargeCategoryChoiceResponse
-    | undefined => {
-    return filter.largeCategory.find(
-      (c) => c.id === currentRefinement.largeCategoryId,
-    );
+  const getCurrentLargeCategory = (): LargeCategoryChoiceResponse | undefined => {
+    return filter.largeCategory.find((c) => c.id === currentRefinement.largeCategoryId);
   };
   const getBroaderCategory = () => {
     if (currentRefinement.mediumCategoryId) {
@@ -36,6 +33,7 @@ export const getFilterGroupCollectionHandler = ({
       if (currentRefinement.largeCategoryId) {
         // 大カテが既に指定されている場合
         const selectedLargeCategory = getCurrentLargeCategory();
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return selectedLargeCategory!!.mediumCategory.map((filter) => {
           return { name: filter.name };
         });
@@ -90,12 +88,10 @@ export const getFilterGroupCollectionHandler = ({
             name: partSize.name,
             range: [partSize.min, partSize.max],
             selectedValue: [
-              currentRefinement.partSizes.find(
-                (value) => value.id === partSize.id,
-              )?.min ?? partSize.min,
-              currentRefinement.partSizes.find(
-                (value) => value.id === partSize.id,
-              )?.max ?? partSize.max,
+              currentRefinement.partSizes.find((value) => value.id === partSize.id)?.min ??
+                partSize.min,
+              currentRefinement.partSizes.find((value) => value.id === partSize.id)?.max ??
+                partSize.max,
             ],
           };
         }),
@@ -179,9 +175,7 @@ export const getFilterGroupCollectionHandler = ({
     );
     if (mediumCategoryChoice) {
       const smallCategoryChoice = mediumCategoryChoice.smallCategory[index];
-      const currentIndex = currentRefinement.smallCategoryIds.indexOf(
-        smallCategoryChoice.id,
-      );
+      const currentIndex = currentRefinement.smallCategoryIds.indexOf(smallCategoryChoice.id);
       const newIds = [...currentRefinement.smallCategoryIds];
       if (currentIndex === -1) {
         newIds.push(smallCategoryChoice.id);
@@ -243,7 +237,7 @@ export const getFilterGroupCollectionHandler = ({
 
   const getPartSizeCallback = () => {
     return {
-      onPresetChanged: (_: number) => undefined,
+      onPresetChanged: () => undefined,
       filterSliderArrayCallback: {
         onChange: (index: number, value: number[]) => {
           const currentIndex = currentRefinement.partSizes.findIndex(

--- a/src/components/rentals/handler/getFilterListHandler.ts
+++ b/src/components/rentals/handler/getFilterListHandler.ts
@@ -1,17 +1,12 @@
 import { FilterChoiceResponse } from "../../../hooks/api/UseRentalFilters";
-import { FilterResponse } from "../../../model/api/response/styling/browse/FilterResponse";
 import { LargeCategoryChoiceResponse } from "../../../model/api/response/styling/browse/LargeCategoryChoiceResponse";
-import {
-  TRentalAppliedFilterData,
-  TType,
-} from "../../../model/rental/TRentalAppliedFilterData";
+import { TRentalAppliedFilterData, TType } from "../../../model/rental/TRentalAppliedFilterData";
 import { Refinement } from "../../../model/selecting/browse/Refinement";
 
 type TArgs = {
   readonly filter: FilterChoiceResponse;
   readonly currentRefinement: Refinement;
   readonly defaultRefinement: Refinement;
-  readonly sort: FilterResponse[];
   readonly categoryId: number;
   readonly onChangeCurrentRefinement: (refinement: Refinement) => void;
 };
@@ -19,7 +14,6 @@ export const getFilterListHandler = ({
   filter,
   currentRefinement,
   defaultRefinement,
-  sort,
   categoryId,
   onChangeCurrentRefinement,
 }: TArgs) => {
@@ -35,9 +29,8 @@ export const getFilterListHandler = ({
     if (selectedMediumCategory && currentRefinement.smallCategoryIds.length) {
       return currentRefinement.smallCategoryIds.map((sId) => {
         return {
-          name: selectedMediumCategory.smallCategory.find(
-            (filter) => filter.id === sId,
-          )!!.name,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          name: selectedMediumCategory.smallCategory.find((filter) => filter.id === sId)!.name,
           type: "smallCategory",
           id: sId,
         };
@@ -65,7 +58,8 @@ export const getFilterListHandler = ({
   const appliedSizeFilter = (): TRentalAppliedFilterData[] => {
     return currentRefinement.sizeIds.map((sizeId) => {
       return {
-        name: filter.size.find((size) => size.id === sizeId)!!.name,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        name: filter.size.find((size) => size.id === sizeId)!.name,
         type: "size",
         id: sizeId,
       };
@@ -74,9 +68,8 @@ export const getFilterListHandler = ({
 
   const appliedPartSizeFilter = (): TRentalAppliedFilterData[] => {
     return currentRefinement.partSizes.map((p) => {
-      const partSizeName = filter.rangesOfPartSizes.find(
-        (partSize) => partSize.id === p.id,
-      )!!.name;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const partSizeName = filter.rangesOfPartSizes.find((partSize) => partSize.id === p.id)!.name;
       return {
         name: `${partSizeName} ${p.min}〜${p.max}`,
         type: "partSize",
@@ -88,7 +81,8 @@ export const getFilterListHandler = ({
   const appliedColorFilter = (): TRentalAppliedFilterData[] => {
     return currentRefinement.colorIds.map((colorId) => {
       return {
-        name: filter.color.find((color) => color.id === colorId)!!.name,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        name: filter.color.find((color) => color.id === colorId)!.name,
         type: "color",
         id: colorId,
       };
@@ -98,7 +92,8 @@ export const getFilterListHandler = ({
   const appliedPatternFilter = (): TRentalAppliedFilterData[] => {
     return currentRefinement.patternIds.map((patternId) => {
       return {
-        name: filter.pattern.find((pattern) => pattern.id === patternId)!!.name,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        name: filter.pattern.find((pattern) => pattern.id === patternId)!.name,
         type: "pattern",
         id: patternId,
       };
@@ -108,7 +103,8 @@ export const getFilterListHandler = ({
   const appliedLogoFilter = (): TRentalAppliedFilterData[] => {
     return currentRefinement.logoIds.map((logoId) => {
       return {
-        name: filter.logo.find((logo) => logo.id === logoId)!!.name,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        name: filter.logo.find((logo) => logo.id === logoId)!.name,
         type: "logo",
         id: logoId,
       };
@@ -137,7 +133,8 @@ export const getFilterListHandler = ({
   const appliedOptionFilter = (): TRentalAppliedFilterData[] => {
     return currentRefinement.optionIds.map((optionId) => {
       return {
-        name: filter.option.find((option) => option.id === optionId)!!.name,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        name: filter.option.find((option) => option.id === optionId)!.name,
         type: "option",
         id: optionId,
       };
@@ -187,9 +184,7 @@ export const getFilterListHandler = ({
       case "smallCategory":
         onChangeCurrentRefinement({
           ...currentRefinement,
-          smallCategoryIds: currentRefinement.smallCategoryIds.filter(
-            (sId) => sId !== id,
-          ),
+          smallCategoryIds: currentRefinement.smallCategoryIds.filter((sId) => sId !== id),
         });
         break;
       case "mediumCategory":

--- a/src/components/rentals/handler/useRentalDetailHandler.ts
+++ b/src/components/rentals/handler/useRentalDetailHandler.ts
@@ -26,14 +26,11 @@ export const useRentalDetailHandler = ({
   defaultRefinement,
   onClickBackButton,
   onChangeCurrentRefinement,
-  onItemSelect,
   currentItemId,
 }: TArgs) => {
   const { rentalId } = useContext(RentalIdContext);
   const [selectedSizeIndex, setSelectedSizeIndex] = useState<number>();
-  const [selectedItem, setSelectedItem] = useState<Omit<TItem, "rank"> | null>(
-    null,
-  );
+  const [selectedItem, setSelectedItem] = useState<Omit<TItem, "rank"> | null>(null);
   const {
     mutate,
     isLoading: isPatchLoading,
@@ -73,10 +70,7 @@ export const useRentalDetailHandler = ({
   };
 
   const detailItemTableData = (): DetailItemTableData => {
-    const columns =
-      selectedSizeIndex === undefined
-        ? []
-        : detail.sizes[selectedSizeIndex].columns;
+    const columns = selectedSizeIndex === undefined ? [] : detail.sizes[selectedSizeIndex].columns;
     const itemRecords =
       selectedSizeIndex === undefined
         ? detail.unsizedItemRecords
@@ -159,9 +153,7 @@ export const useRentalDetailHandler = ({
         {
           onSuccess: () => {
             if (selectedItem) {
-              queryClient.invalidateQueries(
-                `biz/rentals/${rentalId}/rental_coordinate`,
-              );
+              queryClient.invalidateQueries(`biz/rentals/${rentalId}/rental_coordinate`);
               onClickBackButton();
               onChangeCurrentRefinement(defaultRefinement);
             }

--- a/src/components/review/handler/UseLineMessageUrlHandler.ts
+++ b/src/components/review/handler/UseLineMessageUrlHandler.ts
@@ -16,7 +16,7 @@ type LineMessageUrlHandlerArgs = {
   readonly setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
   readonly setIsUrlEditing: React.Dispatch<React.SetStateAction<boolean>>;
   readonly mutate: UseMutateFunction<
-    AxiosResponse<any, any>,
+    AxiosResponse<unknown, unknown>,
     unknown,
     | {
         lineMessageUrl: string;
@@ -41,13 +41,9 @@ export const useLineMessageUrlHandler = ({
   prevLineMessageUrl,
 }: LineMessageUrlHandlerArgs): LineMessageUrlFormHandler => {
   const queryClient = useQueryClient();
-  const handleChangeText = (
-    event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
-  ) => {
+  const handleChangeText = (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
     setLineMessageUrlText(event.target.value);
-    prevLineMessageUrl !== event.target.value
-      ? setIsEditing(true)
-      : setIsEditing(false);
+    prevLineMessageUrl !== event.target.value ? setIsEditing(true) : setIsEditing(false);
     if (prevLineMessageUrl === (null || undefined) && event.target.value === "")
       setIsEditing(false);
   };
@@ -55,9 +51,7 @@ export const useLineMessageUrlHandler = ({
   const handleSendClickButton = () => {
     mutate(undefined, {
       onSuccess: () => {
-        queryClient.invalidateQueries(
-          `styling/coordinates/${coordinateId}/review`,
-        );
+        queryClient.invalidateQueries(`styling/coordinates/${coordinateId}/review`);
         setIsEditing(false);
         callback.onSuccess();
         setIsUrlEditing(false);

--- a/src/components/selecting/SelectionProgress.tsx
+++ b/src/components/selecting/SelectionProgress.tsx
@@ -36,7 +36,7 @@ export const SelectionProgress = (props: SelectionProgressProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const classes = useSelectionProgressStyle();
   const [position, setPosition] = useState<{
-    mouseX: null | Number;
+    mouseX: null | number;
     mouseY: null | number;
   }>(initialState);
   const coordinateId = useContextDefinedState(CoordinateIdContext);
@@ -48,9 +48,7 @@ export const SelectionProgress = (props: SelectionProgressProps) => {
       { footwearId },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries(
-            `styling/coordinates/${coordinateId}/coordinate_footwear`,
-          );
+          queryClient.invalidateQueries(`styling/coordinates/${coordinateId}/coordinate_footwear`);
           setIsOpen(false);
         },
         onError: () => {
@@ -59,7 +57,7 @@ export const SelectionProgress = (props: SelectionProgressProps) => {
       },
     );
   };
-  let steps = [];
+  const steps = [];
   for (let index = 0; index < props.data.rentableItemNum; index++) {
     let stepLabel;
     if (props.data.items.length > index) {
@@ -100,24 +98,19 @@ export const SelectionProgress = (props: SelectionProgressProps) => {
         title={
           <Typography variant="body2">
             {props.data.items.length > index
-              ? props.data.items[index].itemInfo.partSizes.map(
-                  (partSize, index) => (
-                    <Fragment key={index}>
-                      {`${partSize.name}: ${partSize.value ?? ""}`}
-                      <br />
-                    </Fragment>
-                  ),
-                )
+              ? props.data.items[index].itemInfo.partSizes.map((partSize, index) => (
+                  <Fragment key={index}>
+                    {`${partSize.name}: ${partSize.value ?? ""}`}
+                    <br />
+                  </Fragment>
+                ))
               : []}
           </Typography>
         }
         placement="top-start"
       >
         <Step disabled={props.data.items.length < index}>
-          <StepButton
-            className={classes.stepButton}
-            onClick={() => props.callback.onSelect(index)}
-          >
+          <StepButton className={classes.stepButton} onClick={() => props.callback.onSelect(index)}>
             {stepLabel}
           </StepButton>
         </Step>
@@ -129,11 +122,7 @@ export const SelectionProgress = (props: SelectionProgressProps) => {
 
   if (props.data.rentableItemNum !== 0 && props.data.items.length !== 0) {
     completeButton = (
-      <Button
-        variant="contained"
-        color="primary"
-        onClick={props.callback.onClickCompleteButton}
-      >
+      <Button variant="contained" color="primary" onClick={props.callback.onClickCompleteButton}>
         アイテム選択完了
       </Button>
     );
@@ -151,11 +140,7 @@ export const SelectionProgress = (props: SelectionProgressProps) => {
     >
       {completeButton}
       <div style={{ display: "flex" }}>
-        <Stepper
-          activeStep={props.data.selectedIndex}
-          alternativeLabel
-          className={classes.stepper}
-        >
+        <Stepper activeStep={props.data.selectedIndex} alternativeLabel className={classes.stepper}>
           {steps}
         </Stepper>
 
@@ -165,9 +150,7 @@ export const SelectionProgress = (props: SelectionProgressProps) => {
               <Button onClick={() => setIsOpen(true)}>
                 <img
                   style={{ width: 70, height: 70 }}
-                  src={`${HostUrl()}/images/footwear/${
-                    props.data.selectedFootwear.id
-                  }.jpg`}
+                  src={`${HostUrl()}/images/footwear/${props.data.selectedFootwear.id}.jpg`}
                   alt="くつ"
                 />
               </Button>
@@ -211,16 +194,13 @@ export const SelectionProgress = (props: SelectionProgressProps) => {
                   "このアイテムに紐づいているアドバイスも削除されます。よろしいですか？",
                 )
               ) {
-                coordinateItemDestroyMutate(
-                  props.data.items[props.data.selectedIndex].id,
-                  {
-                    onSuccess: () => {
-                      queryClient.invalidateQueries(
-                        `styling/coordinates/${coordinateId}/coordinate_items`,
-                      );
-                    },
+                coordinateItemDestroyMutate(props.data.items[props.data.selectedIndex].id, {
+                  onSuccess: () => {
+                    queryClient.invalidateQueries(
+                      `styling/coordinates/${coordinateId}/coordinate_items`,
+                    );
                   },
-                );
+                });
               }
             }}
           >

--- a/src/components/selecting/arrange/OutfitForm.tsx
+++ b/src/components/selecting/arrange/OutfitForm.tsx
@@ -43,9 +43,7 @@ export const OutfitForm = (props: OutfitFormProps) => {
     });
   }, [props.data.selectedAdviceIds, props.response]);
 
-  const [selectedCategories, setSelectedCategories] = useState(
-    getSelectedCategories()
-  );
+  const [selectedCategories, setSelectedCategories] = useState(getSelectedCategories());
 
   useEffect(() => {
     setSelectedCategories(getSelectedCategories());
@@ -75,14 +73,7 @@ export const OutfitForm = (props: OutfitFormProps) => {
                       inputProps={{ "aria-labelledby": labelId }}
                     />
                   }
-                  label={
-                    <img
-                      src={item.itemImagePath}
-                      width="40px"
-                      height="auto"
-                      alt=""
-                    />
-                  }
+                  label={<img src={item.itemImagePath} width="40px" height="auto" alt="" />}
                 ></FormControlLabel>
               </ListItemIcon>
               <ListItemText>
@@ -94,28 +85,23 @@ export const OutfitForm = (props: OutfitFormProps) => {
       </List>
       <div>
         {props.data.selectedAdviceIds.map((selectedAdviceId, index) => {
-          let selectedCategoryIndex = selectedCategories[index];
-          let selectedCategory =
-            selectedCategoryIndex !== null
-              ? props.response[selectedCategoryIndex]
-              : null;
+          const selectedCategoryIndex = selectedCategories[index];
+          const selectedCategory =
+            selectedCategoryIndex !== null ? props.response[selectedCategoryIndex] : null;
           return (
             <Fragment key={index}>
               <Grid container spacing={2}>
                 <Grid item xs={3} xl={2}>
                   <FormControl fullWidth className={classes.formControl}>
-                    <InputLabel id={`category-select-label-${index}`}>
-                      カテゴリ
-                    </InputLabel>
+                    <InputLabel id={`category-select-label-${index}`}>カテゴリ</InputLabel>
                     <Select
                       labelId={`category-select-label-${index}`}
                       id={`category-select-${index}`}
                       value={selectedCategories[index] ?? ""}
                       label="カテゴリ"
                       onChange={(event) => {
-                        let newSelectedCategories = [...selectedCategories];
-                        newSelectedCategories[index] = event.target
-                          .value as number;
+                        const newSelectedCategories = [...selectedCategories];
+                        newSelectedCategories[index] = event.target.value as number;
                         setSelectedCategories(newSelectedCategories);
                       }}
                     >
@@ -129,19 +115,14 @@ export const OutfitForm = (props: OutfitFormProps) => {
                 </Grid>
                 <Grid item xs={6} xl={4}>
                   <FormControl fullWidth className={classes.adviceFormControl}>
-                    <InputLabel id={`advice-select-label-${index}`}>
-                      アドバイス
-                    </InputLabel>
+                    <InputLabel id={`advice-select-label-${index}`}>アドバイス</InputLabel>
                     <Select
                       labelId={`advice-select-label-${index}`}
                       id={`advice-select-${index}`}
                       value={selectedAdviceId ?? ""}
                       label="アドバイス"
                       onChange={(event) => {
-                        props.callback.onSelectAdvice(
-                          event.target.value as number,
-                          index
-                        );
+                        props.callback.onSelectAdvice(event.target.value as number, index);
                       }}
                     >
                       {selectedCategory?.advice.map((advice) => (
@@ -153,17 +134,14 @@ export const OutfitForm = (props: OutfitFormProps) => {
                   </FormControl>
                 </Grid>
                 <Grid item xs className={classes.adviceDeleteButton}>
-                  <IconButton
-                    onClick={() => props.callback.onClickDeleteAdvice(index)}
-                  >
+                  <IconButton onClick={() => props.callback.onClickDeleteAdvice(index)}>
                     <Delete />
                   </IconButton>
                 </Grid>
               </Grid>
               <Typography variant="body1" marginBottom={2}>
-                {selectedCategory?.advice.find(
-                  (advice) => advice.id === selectedAdviceId
-                )?.description ?? ""}
+                {selectedCategory?.advice.find((advice) => advice.id === selectedAdviceId)
+                  ?.description ?? ""}
               </Typography>
             </Fragment>
           );

--- a/src/components/selecting/arrange/handler/UseArragePatternHandler.ts
+++ b/src/components/selecting/arrange/handler/UseArragePatternHandler.ts
@@ -1,12 +1,12 @@
-import { CoordinateBulkUpdateRequest } from "../../../../model/api/request/styling/coordinate/CoordinateBulkUpdateRequest";
-import { alertClosedWindow } from "../../../../service/shared/alertClosedWindow";
 import { useCallback, useEffect, useState } from "react";
-import { AddedOutfitListData } from "../../../../model/selecting/arrange/props_data/AddedOutfitListData";
-import { AddedOutfitListCallback } from "../callback/AddedOutfitListCallback";
-import { OutfitFormData } from "../../../../model/selecting/arrange/props_data/OutfitFormData";
-import { OutfitFormCallback } from "../callback/OutfitFormCallback";
+import { CoordinateBulkUpdateRequest } from "../../../../model/api/request/styling/coordinate/CoordinateBulkUpdateRequest";
 import { CoordinatePatternIndexResponse } from "../../../../model/api/response/styling/coordinatePattern/CoordinatePatternIndexResponse";
 import { TCoordinateItem } from "../../../../model/coordinateItem/TCoordinateItem";
+import { AddedOutfitListData } from "../../../../model/selecting/arrange/props_data/AddedOutfitListData";
+import { OutfitFormData } from "../../../../model/selecting/arrange/props_data/OutfitFormData";
+import { alertClosedWindow } from "../../../../service/shared/alertClosedWindow";
+import { AddedOutfitListCallback } from "../callback/AddedOutfitListCallback";
+import { OutfitFormCallback } from "../callback/OutfitFormCallback";
 
 export interface ArrangePatternHandler {
   coordinates: CoordinateBulkUpdateRequest[];
@@ -20,7 +20,7 @@ export interface ArrangePatternHandler {
 
 export const useArrangePatternHandler = (
   items: TCoordinateItem[],
-  responses: CoordinatePatternIndexResponse
+  responses: CoordinatePatternIndexResponse,
 ): ArrangePatternHandler => {
   const defaultCoordinate = {
     id: null,
@@ -41,9 +41,7 @@ export const useArrangePatternHandler = (
   };
   const [coordinates, setCoordinates] =
     useState<CoordinateBulkUpdateRequest[]>(formattedCoordinates);
-  const [editingOutfitIndex, setEditingOutfitIndex] = useState<number>(
-    coordinates.length
-  );
+  const [editingOutfitIndex, setEditingOutfitIndex] = useState<number>(coordinates.length);
   const [editingOutfit, setEditingOutfit] =
     useState<CoordinateBulkUpdateRequest>(defaultCoordinate);
   const [isPostComplete, setIsPostComplete] = useState(false);
@@ -64,7 +62,7 @@ export const useArrangePatternHandler = (
                 categoryName: string;
                 imagePath: string;
               }[],
-              itemId
+              itemId,
             ) => {
               const item = items.find((item) => item.itemInfo.id === itemId);
               if (item) {
@@ -76,7 +74,7 @@ export const useArrangePatternHandler = (
               }
               return result;
             },
-            []
+            [],
           ),
           advices: coordinate.adviceIds.map((adviceId) => {
             let adviceTitle = "";
@@ -121,7 +119,7 @@ export const useArrangePatternHandler = (
   };
 
   const outfitFormData = (): OutfitFormData => {
-    let selectedAdviceIdArray: (number | null)[] = [...editingOutfit.adviceIds];
+    const selectedAdviceIdArray: (number | null)[] = [...editingOutfit.adviceIds];
     selectedAdviceIdArray.push(null);
     return {
       items: items.map((item) => {
@@ -141,7 +139,7 @@ export const useArrangePatternHandler = (
   const outfitFormCallback = (): OutfitFormCallback => {
     return {
       onClickAddOutfit: () => {
-        let newOutfits = [...coordinates];
+        const newOutfits = [...coordinates];
         if (editingOutfitIndex >= newOutfits.length) {
           newOutfits.push(editingOutfit);
         } else {
@@ -153,7 +151,7 @@ export const useArrangePatternHandler = (
         setIsPostComplete(false);
       },
       onSelectAdvice: (adviceId: number, index: number) => {
-        let newAdviceIds = [...editingOutfit.adviceIds];
+        const newAdviceIds = [...editingOutfit.adviceIds];
         if (index > editingOutfit.adviceIds.length) {
           newAdviceIds.push(adviceId);
         } else {

--- a/src/components/selecting/arrange/style/UseArrangePatternStyle.ts
+++ b/src/components/selecting/arrange/style/UseArrangePatternStyle.ts
@@ -1,12 +1,10 @@
-import { Theme } from "@mui/material/styles";
-
 import createStyles from "@mui/styles/createStyles";
 import makeStyles from "@mui/styles/makeStyles";
 
-export const useArrangePatternStyle = makeStyles((theme: Theme) =>
+export const useArrangePatternStyle = makeStyles(() =>
   createStyles({
     completeButton: {
       margin: "0 0 0 auto",
     },
-  })
+  }),
 );

--- a/src/components/selecting/browse/Browse.tsx
+++ b/src/components/selecting/browse/Browse.tsx
@@ -1,8 +1,8 @@
 import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
-import React, { useState } from "react";
+import { useState } from "react";
 import { BrowseSearchPrerequisiteResponse } from "../../../model/api/response/styling/browse/BrowseSearchPrerequisiteResponse";
-import { ItemBrowseCallback } from "./callback/ItemBrowseCallback";
 import { ItemBrowseContainer } from "./ItemBrowseContainer";
+import { ItemBrowseCallback } from "./callback/ItemBrowseCallback";
 import { useBrowseStyle } from "./style/UseBrowseStyle";
 
 interface BrowseProps {
@@ -39,7 +39,8 @@ export const Browse = (props: BrowseProps) => {
         <ItemBrowseContainer
           key={categoryId}
           callback={props.callback}
-          categoryId={categoryId!!}
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          categoryId={categoryId!}
           currentSelectedItemId={props.currentSelectedItemId}
         />
       )}

--- a/src/components/selecting/browse/BrowseDetail.tsx
+++ b/src/components/selecting/browse/BrowseDetail.tsx
@@ -1,3 +1,4 @@
+import { ArrowBack } from "@mui/icons-material";
 import {
   Box,
   Button,
@@ -9,19 +10,17 @@ import {
   Paper,
   Typography,
 } from "@mui/material";
-import { ArrowBack } from "@mui/icons-material";
-import React from "react";
 import ReactImageGallery from "react-image-gallery";
+import { HostUrl } from "../../../model/HostUrl";
 import { DetailResponse } from "../../../model/api/response/styling/browse/DetailResponse";
 import { DetailStatus } from "../../../model/selecting/browse/DetailStatus";
-import { BrowseDetailCallback } from "./callback/BrowseDetailCallback";
+import { theme } from "../../style/Theme";
 import { DetailItemTable } from "./DetailItemTable";
 import { DetailSizeButtonArray } from "./DetailSizeButtonArray";
+import { ValidationDialog } from "./ValidationDialog";
+import { BrowseDetailCallback } from "./callback/BrowseDetailCallback";
 import { useBrowseDetailHandler } from "./handler/UseBrowseDetailHandler";
 import { useBrowseDetailStyle } from "./style/UseBrowseDetailStyle";
-import { ValidationDialog } from "./ValidationDialog";
-import { HostUrl } from "../../../model/HostUrl";
-import { theme } from "../../style/Theme";
 
 interface BrowseDetailProps {
   response: DetailResponse;
@@ -41,10 +40,10 @@ export const BrowseDetail = (props: BrowseDetailProps) => {
   const handler = useBrowseDetailHandler(
     props.response,
     props.callback,
-    props.previousSelectedItemId ?? undefined
+    props.previousSelectedItemId ?? undefined,
   );
 
-  let itemImage: itemImageGallery[] = [
+  const itemImage: itemImageGallery[] = [
     {
       originalImagePath: props.response.itemImagePath.large,
       thumbnailImagePath: props.response.itemImagePath.thumb,
@@ -53,16 +52,14 @@ export const BrowseDetail = (props: BrowseDetailProps) => {
     },
   ];
 
-  let wearingImages: itemImageGallery[] = props.response.wearingImages.map(
-    (wearingImage) => {
-      return {
-        originalImagePath: wearingImage.imagePath.large,
-        thumbnailImagePath: wearingImage.imagePath.thumb,
-        itemSize: wearingImage.itemSize,
-        height: wearingImage.height,
-      };
-    }
-  );
+  const wearingImages: itemImageGallery[] = props.response.wearingImages.map((wearingImage) => {
+    return {
+      originalImagePath: wearingImage.imagePath.large,
+      thumbnailImagePath: wearingImage.imagePath.thumb,
+      itemSize: wearingImage.itemSize,
+      height: wearingImage.height,
+    };
+  });
 
   let dialog;
   if (handler.selectedItem) {
@@ -79,10 +76,7 @@ export const BrowseDetail = (props: BrowseDetailProps) => {
 
   return (
     <>
-      <IconButton
-        onClick={() => props.callback.onClickBackButton()}
-        size="large"
-      >
+      <IconButton onClick={() => props.callback.onClickBackButton()} size="large">
         <ArrowBack />
       </IconButton>
       <Paper className={classes.itemInfo}>
@@ -108,14 +102,8 @@ export const BrowseDetail = (props: BrowseDetailProps) => {
           />
         </div>
         <div className={classes.itemInfoTextContainer}>
-          <Typography
-            className={classes.itemInfoText}
-            variant="h5"
-            color="textSecondary"
-          >
-            {`${props.response.seriesName ?? ""}, ${
-              props.response.seriesFeature ?? ""
-            }`}
+          <Typography className={classes.itemInfoText} variant="h5" color="textSecondary">
+            {`${props.response.seriesName ?? ""}, ${props.response.seriesFeature ?? ""}`}
           </Typography>
           <Typography className={classes.itemInfoText} variant="h4">
             {props.response.categoryName}
@@ -123,9 +111,7 @@ export const BrowseDetail = (props: BrowseDetailProps) => {
           <Typography className={classes.itemInfoText} variant="h3">
             {props.response.brandName}
           </Typography>
-          <Typography variant="body1">
-            メインカラー：{props.response.mainColor.name}
-          </Typography>
+          <Typography variant="body1">メインカラー：{props.response.mainColor.name}</Typography>
           <div>
             <Box display="flex">
               <img
@@ -137,9 +123,7 @@ export const BrowseDetail = (props: BrowseDetailProps) => {
               />
             </Box>
           </div>
-          <Typography variant="body1">
-            サブカラー：{props.response.subColor.name}
-          </Typography>
+          <Typography variant="body1">サブカラー：{props.response.subColor.name}</Typography>
           <div>
             <Box display="flex">
               <img
@@ -151,18 +135,14 @@ export const BrowseDetail = (props: BrowseDetailProps) => {
               />
             </Box>
           </div>
-          <Typography variant="body1">
-            サイズ：{handler.selectedSizeName()}
-          </Typography>
+          <Typography variant="body1">サイズ：{handler.selectedSizeName()}</Typography>
           <div>
             <DetailSizeButtonArray
               data={handler.detailSizeButtonArrayData()}
               callback={handler.detailSizeButtonArrayCallback()}
             />
           </div>
-          <Typography variant="body1">
-            アイテム：{handler.selectedItemId()}
-          </Typography>
+          <Typography variant="body1">アイテム：{handler.selectedItemId()}</Typography>
           <div className={classes.itemTableContainer}>
             <DetailItemTable
               data={handler.detailItemTableData()}
@@ -185,10 +165,7 @@ export const BrowseDetail = (props: BrowseDetailProps) => {
       <Dialog open={handler.isPostLoading} disableEscapeKeyDown>
         <CircularProgress />
       </Dialog>
-      <Dialog
-        open={handler.postError !== null}
-        onClose={handler.resetPostError}
-      >
+      <Dialog open={handler.postError !== null} onClose={handler.resetPostError}>
         <DialogTitle>エラー</DialogTitle>
         <DialogContent>
           <Typography>{handler.postError?.message ?? ""}</Typography>

--- a/src/components/selecting/browse/FilterCheckboxArray.tsx
+++ b/src/components/selecting/browse/FilterCheckboxArray.tsx
@@ -1,13 +1,5 @@
-import {
-  Checkbox,
-  IconButton,
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
-} from "@mui/material";
 import { ArrowBack } from "@mui/icons-material";
-import React from "react";
+import { Checkbox, IconButton, List, ListItem, ListItemIcon, ListItemText } from "@mui/material";
 import { FilterCheckboxData } from "../../../model/selecting/browse/props_data/FilterCheckboxData";
 import { FilterCheckboxArrayCallback } from "./callback/FilterCheckboxArrayCallback";
 
@@ -23,7 +15,8 @@ export const FilterCheckboxArray = (props: FilterCheckboxArrayProps) => {
     backButton = (
       <IconButton
         onClick={() => {
-          props.callback.onClickBackButton!!();
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          props.callback.onClickBackButton!();
         }}
         size="large"
       >

--- a/src/components/selecting/browse/FilterFormalRank.tsx
+++ b/src/components/selecting/browse/FilterFormalRank.tsx
@@ -7,7 +7,7 @@ interface FilterSliderProps {
   onChange: (value: FormalRankRefinement) => void;
 }
 
-export const FilterFormalRank = ({ data, onChange }: FilterSliderProps) => {
+export const FilterFormalRank = ({ onChange }: FilterSliderProps) => {
   const [currentValue, setCurrentValue] = useState([1, 10]);
 
   const onSlided = (value: number | number[]) => {

--- a/src/components/selecting/browse/FilterGroupCollection.tsx
+++ b/src/components/selecting/browse/FilterGroupCollection.tsx
@@ -8,13 +8,13 @@ import {
   Typography,
 } from "@mui/material";
 import { FilterGroupCollectionData } from "../../../model/selecting/browse/props_data/FilterGroupCollectionData";
-import { FilterGroupCollectionCallback } from "./callback/FilterGroupCollectionCallback";
 import { FilterCategoryGroup } from "./FilterCategoryGroup";
 import { FilterCheckboxArray } from "./FilterCheckboxArray";
 import { FilterFormalRank } from "./FilterFormalRank";
 import { FilterMediaArray } from "./FilterMediaArray";
 import { FilterPartSize } from "./FilterPartSize";
 import { FilterSizeArray } from "./FilterSizeArray";
+import { FilterGroupCollectionCallback } from "./callback/FilterGroupCollectionCallback";
 import { useFilterGroupCollectionStyle } from "./style/UseFilterGroupCollectionStyle";
 
 interface FilterGroupCollectionProps {
@@ -53,10 +53,7 @@ export const FilterGroupCollection = (props: FilterGroupCollectionProps) => {
           <Typography variant="body2">サイズ</Typography>
         </AccordionSummary>
         <AccordionDetails>
-          <FilterSizeArray
-            data={props.data.sizeData}
-            callback={props.callback.sizeCallback}
-          />
+          <FilterSizeArray data={props.data.sizeData} callback={props.callback.sizeCallback} />
         </AccordionDetails>
       </Accordion>
       <Accordion>
@@ -207,6 +204,7 @@ export const FilterGroupCollection = (props: FilterGroupCollectionProps) => {
         InputProps={{ startAdornment: <Search /> }}
         color="secondary"
         type="number"
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         onKeyPress={(event: any) => {
           if (event.key === "Enter") {
             props.callback.onItemIdChanged(event.target.value as number);

--- a/src/components/selecting/browse/handler/UseCategoryRefinementHandler.ts
+++ b/src/components/selecting/browse/handler/UseCategoryRefinementHandler.ts
@@ -10,19 +10,19 @@ export interface CategoryRefinementHandler {
     choice: LargeCategoryChoiceResponse[],
     largeCategoryId: number | null,
     mediumCategoryId: number | null,
-    smallCategoryIds: number[]
+    smallCategoryIds: number[],
   ) => FilterCategoryGroupCallback;
   categoryData: (
     choice: LargeCategoryChoiceResponse[],
     largeCategoryId: number | null,
     mediumCategoryId: number | null,
-    smallCategoryIds: number[]
+    smallCategoryIds: number[],
   ) => FilterCategoryGroupData;
   appliedFilters: (
     choice: LargeCategoryChoiceResponse[],
     largeCategoryId: number | null,
     mediumCategoryId: number | null,
-    smallCategoryIds: number[]
+    smallCategoryIds: number[],
   ) => AppliedFilterData[];
   deleteLargeCategoryFilter: () => void;
   deleteMediumCategoryFilter: () => void;
@@ -37,12 +37,12 @@ export interface CategoryRefinementCallback {
 }
 
 export const useCategoryRefinementHandler = (
-  callback: CategoryRefinementCallback
+  callback: CategoryRefinementCallback,
 ): CategoryRefinementHandler => {
   const onBroaderCategoryChanged = (
     index: number,
     choice: LargeCategoryChoiceResponse[],
-    largeCategoryId: number | null
+    largeCategoryId: number | null,
   ) => {
     if (largeCategoryId) {
       onMediumCategoryChanged(index, choice, largeCategoryId);
@@ -51,25 +51,18 @@ export const useCategoryRefinementHandler = (
     }
   };
 
-  const onLargeCategoryChanged = (
-    index: number,
-    choice: LargeCategoryChoiceResponse[]
-  ) => {
+  const onLargeCategoryChanged = (index: number, choice: LargeCategoryChoiceResponse[]) => {
     callback.onLargeCategoryChange(choice[index].id);
   };
 
   const onMediumCategoryChanged = (
     index: number,
     choice: LargeCategoryChoiceResponse[],
-    currentLargeCategoryId: number
+    currentLargeCategoryId: number,
   ) => {
-    const largeCategoryChoice = choice.find(
-      (elem) => elem.id === currentLargeCategoryId
-    );
+    const largeCategoryChoice = choice.find((elem) => elem.id === currentLargeCategoryId);
     if (largeCategoryChoice) {
-      callback.onMediumCategoryChange(
-        largeCategoryChoice.mediumCategory[index].id
-      );
+      callback.onMediumCategoryChange(largeCategoryChoice.mediumCategory[index].id);
     }
   };
 
@@ -78,18 +71,16 @@ export const useCategoryRefinementHandler = (
     choice: LargeCategoryChoiceResponse[],
     largeCategoryId: number | null,
     mediumCategoryId: number | null,
-    smallCategoryIds: number[]
+    smallCategoryIds: number[],
   ) => {
-    const largeCategoryChoice = choice.find(
-      (elem) => elem.id === largeCategoryId
-    );
+    const largeCategoryChoice = choice.find((elem) => elem.id === largeCategoryId);
     const mediumCategoryChoice = largeCategoryChoice?.mediumCategory.find(
-      (elem) => elem.id === mediumCategoryId
+      (elem) => elem.id === mediumCategoryId,
     );
     if (mediumCategoryChoice) {
       const newSmallCategories = newFilterArray(
         mediumCategoryChoice.smallCategory[index].id,
-        smallCategoryIds
+        smallCategoryIds,
       );
       callback.onSmallCategoryChange(newSmallCategories);
     }
@@ -109,7 +100,7 @@ export const useCategoryRefinementHandler = (
   const broaderCategoryData = (
     choice: LargeCategoryChoiceResponse[],
     largeCategoryId: number | null,
-    mediumCategoryId: number | null
+    mediumCategoryId: number | null,
   ): FilterListButtonData[] | null => {
     if (mediumCategoryId) {
       // 中カテが既に指定されている場合
@@ -117,10 +108,9 @@ export const useCategoryRefinementHandler = (
     } else {
       if (largeCategoryId) {
         // 大カテが既に指定されている場合
-        const largeCategoryChoice = choice.find(
-          (elem) => elem.id === largeCategoryId
-        );
-        return largeCategoryChoice!!.mediumCategory.map((filter) => {
+        const largeCategoryChoice = choice.find((elem) => elem.id === largeCategoryId);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return largeCategoryChoice!.mediumCategory.map((filter) => {
           return { name: filter.name };
         });
       } else {
@@ -135,13 +125,11 @@ export const useCategoryRefinementHandler = (
     choice: LargeCategoryChoiceResponse[],
     largeCategoryId: number | null,
     mediumCategoryId: number | null,
-    smallCategoryIds: number[]
+    smallCategoryIds: number[],
   ): FilterCheckboxData[] => {
-    const largeCategoryChoice = choice.find(
-      (elem) => elem.id === largeCategoryId
-    );
+    const largeCategoryChoice = choice.find((elem) => elem.id === largeCategoryId);
     const mediumCategoryChoice = largeCategoryChoice?.mediumCategory.find(
-      (elem) => elem.id === mediumCategoryId
+      (elem) => elem.id === mediumCategoryId,
     );
     if (mediumCategoryChoice) {
       return mediumCategoryChoice.smallCategory.map((filter) => {
@@ -159,12 +147,11 @@ export const useCategoryRefinementHandler = (
     choice: LargeCategoryChoiceResponse[],
     largeCategoryId: number | null,
     mediumCategoryId: number | null,
-    smallCategoryIds: number[]
+    smallCategoryIds: number[],
   ): FilterCategoryGroupCallback => {
     return {
       broaderCategoryCallback: {
-        onClick: (index: number) =>
-          onBroaderCategoryChanged(index, choice, largeCategoryId),
+        onClick: (index: number) => onBroaderCategoryChanged(index, choice, largeCategoryId),
       },
       smallerCategoryCallback: {
         onClick: (index: number) =>
@@ -173,7 +160,7 @@ export const useCategoryRefinementHandler = (
             choice,
             largeCategoryId,
             mediumCategoryId,
-            smallCategoryIds
+            smallCategoryIds,
           ),
         onClickBackButton: () => {
           callback.onMediumCategoryCancelled();
@@ -186,19 +173,15 @@ export const useCategoryRefinementHandler = (
     choice: LargeCategoryChoiceResponse[],
     largeCategoryId: number | null,
     mediumCategoryId: number | null,
-    smallCategoryIds: number[]
+    smallCategoryIds: number[],
   ): FilterCategoryGroupData => {
     return {
-      broaderCategoryData: broaderCategoryData(
-        choice,
-        largeCategoryId,
-        mediumCategoryId
-      ),
+      broaderCategoryData: broaderCategoryData(choice, largeCategoryId, mediumCategoryId),
       smallCategoryData: smallCategoryData(
         choice,
         largeCategoryId,
         mediumCategoryId,
-        smallCategoryIds
+        smallCategoryIds,
       ),
     };
   };
@@ -207,20 +190,17 @@ export const useCategoryRefinementHandler = (
     choice: LargeCategoryChoiceResponse[],
     largeCategoryId: number | null,
     mediumCategoryId: number | null,
-    smallCategoryIds: number[]
+    smallCategoryIds: number[],
   ): AppliedFilterData[] => {
-    const largeCategoryChoice = choice.find(
-      (elem) => elem.id === largeCategoryId
-    );
+    const largeCategoryChoice = choice.find((elem) => elem.id === largeCategoryId);
     const mediumCategoryChoice = largeCategoryChoice?.mediumCategory.find(
-      (elem) => elem.id === mediumCategoryId
+      (elem) => elem.id === mediumCategoryId,
     );
     if (mediumCategoryChoice && smallCategoryIds.length) {
       return smallCategoryIds.map((categoryId) => {
         return {
-          name: mediumCategoryChoice.smallCategory.find(
-            (filter) => filter.id === categoryId
-          )!!.name,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          name: mediumCategoryChoice.smallCategory.find((filter) => filter.id === categoryId)!.name,
         };
       });
     }
@@ -238,7 +218,7 @@ export const useCategoryRefinementHandler = (
   };
 
   const deleteSmallCategoryFilter = (currentIds: number[], index: number) => {
-    let newSmallCategories = [...currentIds];
+    const newSmallCategories = [...currentIds];
     newSmallCategories.splice(index, 1);
     callback.onSmallCategoryChange(newSmallCategories);
   };

--- a/src/components/selecting/browse/handler/UseColorRefinementHandler.ts
+++ b/src/components/selecting/browse/handler/UseColorRefinementHandler.ts
@@ -4,23 +4,14 @@ import { FilterMediaData } from "../../../../model/selecting/browse/props_data/F
 import { FilterMediaArrayCallback } from "../callback/FilterMediaArrayCallback";
 
 export interface ColorRefinementHandler {
-  colorCallback: (
-    choice: FilterMediaResponse[],
-    currentIds: number[]
-  ) => FilterMediaArrayCallback;
-  colorData: (
-    choice: FilterMediaResponse[],
-    currentIds: number[]
-  ) => FilterMediaData[];
-  appliedFilters: (
-    choice: FilterMediaResponse[],
-    currentIds: number[]
-  ) => AppliedFilterData[];
+  colorCallback: (choice: FilterMediaResponse[], currentIds: number[]) => FilterMediaArrayCallback;
+  colorData: (choice: FilterMediaResponse[], currentIds: number[]) => FilterMediaData[];
+  appliedFilters: (choice: FilterMediaResponse[], currentIds: number[]) => AppliedFilterData[];
   deleteFilter: (currentIds: number[], index: number) => void;
 }
 
 export const useColorRefinementHandler = (
-  onChange: (newIds: number[]) => void
+  onChange: (newIds: number[]) => void,
 ): ColorRefinementHandler => {
   const newFilterArray = (id: number, currentArray: number[]): number[] => {
     const currentIndex = currentArray.indexOf(id);
@@ -35,7 +26,7 @@ export const useColorRefinementHandler = (
 
   const colorCallback = (
     choice: FilterMediaResponse[],
-    currentIds: number[]
+    currentIds: number[],
   ): FilterMediaArrayCallback => {
     return {
       onClick: (index: number) => {
@@ -45,10 +36,7 @@ export const useColorRefinementHandler = (
     };
   };
 
-  const colorData = (
-    choice: FilterMediaResponse[],
-    currentIds: number[]
-  ): FilterMediaData[] => {
+  const colorData = (choice: FilterMediaResponse[], currentIds: number[]): FilterMediaData[] => {
     return choice.map((filter) => {
       return {
         name: filter.name,
@@ -60,15 +48,16 @@ export const useColorRefinementHandler = (
 
   const appliedFilters = (
     choice: FilterMediaResponse[],
-    currentIds: number[]
+    currentIds: number[],
   ): AppliedFilterData[] => {
     return currentIds.map((currentId) => {
-      return { name: choice.find((filter) => filter.id === currentId)!!.name };
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return { name: choice.find((filter) => filter.id === currentId)!.name };
     });
   };
 
   const deleteFilter = (currentIds: number[], index: number) => {
-    let newColors = [...currentIds];
+    const newColors = [...currentIds];
     newColors.splice(index, 1);
     onChange(newColors);
   };

--- a/src/components/selecting/browse/handler/UseFilterSliderArrayHandler.ts
+++ b/src/components/selecting/browse/handler/UseFilterSliderArrayHandler.ts
@@ -4,21 +4,15 @@ import { FilterSliderArrayCallback } from "../callback/FilterSliderArrayCallback
 
 export interface FilterSliderArrayHandler {
   value: (index: number) => number[];
-  onChangeCommitted: (
-    index: number
-  ) => (event: object, value: number | number[]) => void;
-  onChange: (
-    index: number
-  ) => (event: object, value: number | number[]) => void;
+  onChangeCommitted: (index: number) => (event: object, value: number | number[]) => void;
+  onChange: (index: number) => (event: object, value: number | number[]) => void;
 }
 
 export const useFilterSliderArrayHandler = (
   data: FilterSliderData[],
-  callback: FilterSliderArrayCallback
+  callback: FilterSliderArrayCallback,
 ): FilterSliderArrayHandler => {
-  const [currentValues, setCurrentValues] = useState(
-    data.map((row) => row.selectedValue)
-  );
+  const [currentValues, setCurrentValues] = useState(data.map((row) => row.selectedValue));
 
   useEffect(() => {
     setCurrentValues(data.map((row) => row.selectedValue));
@@ -26,18 +20,12 @@ export const useFilterSliderArrayHandler = (
 
   const value = (index: number) => currentValues[index];
 
-  const onChangeCommitted = (index: number) => (
-    event: object,
-    value: number | number[]
-  ) => {
+  const onChangeCommitted = (index: number) => (event: object, value: number | number[]) => {
     callback.onChange(index, value as number[]);
   };
 
-  const onChange = (index: number) => (
-    event: object,
-    value: number | number[]
-  ) => {
-    let newValues = [...currentValues];
+  const onChange = (index: number) => (event: object, value: number | number[]) => {
+    const newValues = [...currentValues];
     newValues[index] = value as number[];
     setCurrentValues(newValues);
   };

--- a/src/components/selecting/browse/handler/UseLogoRefinementHandler.ts
+++ b/src/components/selecting/browse/handler/UseLogoRefinementHandler.ts
@@ -4,23 +4,14 @@ import { FilterMediaData } from "../../../../model/selecting/browse/props_data/F
 import { FilterMediaArrayCallback } from "../callback/FilterMediaArrayCallback";
 
 export interface LogoRefinementHandler {
-  logoCallback: (
-    choice: FilterMediaResponse[],
-    currentIds: number[]
-  ) => FilterMediaArrayCallback;
-  logoData: (
-    choice: FilterMediaResponse[],
-    currentIds: number[]
-  ) => FilterMediaData[];
-  appliedFilters: (
-    choice: FilterMediaResponse[],
-    currentIds: number[]
-  ) => AppliedFilterData[];
+  logoCallback: (choice: FilterMediaResponse[], currentIds: number[]) => FilterMediaArrayCallback;
+  logoData: (choice: FilterMediaResponse[], currentIds: number[]) => FilterMediaData[];
+  appliedFilters: (choice: FilterMediaResponse[], currentIds: number[]) => AppliedFilterData[];
   deleteFilter: (currentIds: number[], index: number) => void;
 }
 
 export const useLogoRefinementHandler = (
-  onChange: (newIds: number[]) => void
+  onChange: (newIds: number[]) => void,
 ): LogoRefinementHandler => {
   const newFilterArray = (id: number, currentArray: number[]): number[] => {
     const currentIndex = currentArray.indexOf(id);
@@ -35,7 +26,7 @@ export const useLogoRefinementHandler = (
 
   const logoCallback = (
     choice: FilterMediaResponse[],
-    currentIds: number[]
+    currentIds: number[],
   ): FilterMediaArrayCallback => {
     return {
       onClick: (index: number) => {
@@ -45,10 +36,7 @@ export const useLogoRefinementHandler = (
     };
   };
 
-  const logoData = (
-    choice: FilterMediaResponse[],
-    currentIds: number[]
-  ): FilterMediaData[] => {
+  const logoData = (choice: FilterMediaResponse[], currentIds: number[]): FilterMediaData[] => {
     return choice.map((filter) => {
       return {
         name: filter.name,
@@ -60,15 +48,16 @@ export const useLogoRefinementHandler = (
 
   const appliedFilters = (
     choice: FilterMediaResponse[],
-    currentIds: number[]
+    currentIds: number[],
   ): AppliedFilterData[] => {
     return currentIds.map((currentId) => {
-      return { name: choice.find((filter) => filter.id === currentId)!!.name };
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return { name: choice.find((filter) => filter.id === currentId)!.name };
     });
   };
 
   const deleteFilter = (currentIds: number[], index: number) => {
-    let newLogos = [...currentIds];
+    const newLogos = [...currentIds];
     newLogos.splice(index, 1);
     onChange(newLogos);
   };

--- a/src/components/selecting/browse/handler/UseNgRefinementHandler.ts
+++ b/src/components/selecting/browse/handler/UseNgRefinementHandler.ts
@@ -4,23 +4,14 @@ import { FilterCheckboxData } from "../../../../model/selecting/browse/props_dat
 import { FilterCheckboxArrayCallback } from "../callback/FilterCheckboxArrayCallback";
 
 export interface NgRefinementHandler {
-  ngCallback: (
-    choice: FilterResponse[],
-    currentIds: number[]
-  ) => FilterCheckboxArrayCallback;
-  ngData: (
-    choice: FilterResponse[],
-    currentIds: number[]
-  ) => FilterCheckboxData[];
-  appliedFilters: (
-    choice: FilterResponse[],
-    currentIds: number[]
-  ) => AppliedFilterData[];
+  ngCallback: (choice: FilterResponse[], currentIds: number[]) => FilterCheckboxArrayCallback;
+  ngData: (choice: FilterResponse[], currentIds: number[]) => FilterCheckboxData[];
+  appliedFilters: (choice: FilterResponse[], currentIds: number[]) => AppliedFilterData[];
   deleteFilter: (currentIds: number[], index: number) => void;
 }
 
 export const useNgRefinementHandler = (
-  onChange: (newIds: number[]) => void
+  onChange: (newIds: number[]) => void,
 ): NgRefinementHandler => {
   const newFilterArray = (id: number, currentArray: number[]): number[] => {
     const currentIndex = currentArray.indexOf(id);
@@ -35,7 +26,7 @@ export const useNgRefinementHandler = (
 
   const ngCallback = (
     choice: FilterResponse[],
-    currentIds: number[]
+    currentIds: number[],
   ): FilterCheckboxArrayCallback => {
     return {
       onClick: (index: number) => {
@@ -45,10 +36,7 @@ export const useNgRefinementHandler = (
     };
   };
 
-  const ngData = (
-    choice: FilterResponse[],
-    currentIds: number[]
-  ): FilterCheckboxData[] => {
+  const ngData = (choice: FilterResponse[], currentIds: number[]): FilterCheckboxData[] => {
     return choice.map((filter) => {
       return {
         name: filter.name,
@@ -57,17 +45,15 @@ export const useNgRefinementHandler = (
     });
   };
 
-  const appliedFilters = (
-    choice: FilterResponse[],
-    currentIds: number[]
-  ): AppliedFilterData[] => {
+  const appliedFilters = (choice: FilterResponse[], currentIds: number[]): AppliedFilterData[] => {
     return currentIds.map((currentId) => {
-      return { name: choice.find((filter) => filter.id === currentId)!!.name };
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return { name: choice.find((filter) => filter.id === currentId)!.name };
     });
   };
 
   const deleteFilter = (currentIds: number[], index: number) => {
-    let newNgs = [...currentIds];
+    const newNgs = [...currentIds];
     newNgs.splice(index, 1);
     onChange(newNgs);
   };

--- a/src/components/selecting/browse/handler/UseOptionRefinementHandler.ts
+++ b/src/components/selecting/browse/handler/UseOptionRefinementHandler.ts
@@ -4,23 +4,14 @@ import { FilterCheckboxData } from "../../../../model/selecting/browse/props_dat
 import { FilterCheckboxArrayCallback } from "../callback/FilterCheckboxArrayCallback";
 
 export interface OptionRefinementHandler {
-  optionCallback: (
-    choice: FilterResponse[],
-    currentIds: number[]
-  ) => FilterCheckboxArrayCallback;
-  optionData: (
-    choice: FilterResponse[],
-    currentIds: number[]
-  ) => FilterCheckboxData[];
-  appliedFilters: (
-    choice: FilterResponse[],
-    currentIds: number[]
-  ) => AppliedFilterData[];
+  optionCallback: (choice: FilterResponse[], currentIds: number[]) => FilterCheckboxArrayCallback;
+  optionData: (choice: FilterResponse[], currentIds: number[]) => FilterCheckboxData[];
+  appliedFilters: (choice: FilterResponse[], currentIds: number[]) => AppliedFilterData[];
   deleteFilter: (currentIds: number[], index: number) => void;
 }
 
 export const useOptionRefinementHandler = (
-  onChange: (newIds: number[]) => void
+  onChange: (newIds: number[]) => void,
 ): OptionRefinementHandler => {
   const newFilterArray = (id: number, currentArray: number[]): number[] => {
     const currentIndex = currentArray.indexOf(id);
@@ -35,7 +26,7 @@ export const useOptionRefinementHandler = (
 
   const optionCallback = (
     choice: FilterResponse[],
-    currentIds: number[]
+    currentIds: number[],
   ): FilterCheckboxArrayCallback => {
     return {
       onClick: (index: number) => {
@@ -45,10 +36,7 @@ export const useOptionRefinementHandler = (
     };
   };
 
-  const optionData = (
-    choice: FilterResponse[],
-    currentIds: number[]
-  ): FilterCheckboxData[] => {
+  const optionData = (choice: FilterResponse[], currentIds: number[]): FilterCheckboxData[] => {
     return choice.map((filter) => {
       return {
         name: filter.name,
@@ -57,17 +45,15 @@ export const useOptionRefinementHandler = (
     });
   };
 
-  const appliedFilters = (
-    choice: FilterResponse[],
-    currentIds: number[]
-  ): AppliedFilterData[] => {
+  const appliedFilters = (choice: FilterResponse[], currentIds: number[]): AppliedFilterData[] => {
     return currentIds.map((currentId) => {
-      return { name: choice.find((filter) => filter.id === currentId)!!.name };
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return { name: choice.find((filter) => filter.id === currentId)!.name };
     });
   };
 
   const deleteFilter = (currentIds: number[], index: number) => {
-    let newOptions = [...currentIds];
+    const newOptions = [...currentIds];
     newOptions.splice(index, 1);
     onChange(newOptions);
   };

--- a/src/components/selecting/browse/handler/UsePartSizeRefinementHandler.ts
+++ b/src/components/selecting/browse/handler/UsePartSizeRefinementHandler.ts
@@ -1,36 +1,34 @@
 import { useState } from "react";
+import { FilterPartSizeResponse } from "../../../../model/api/response/styling/browse/FilterPartSizeResponse";
+import { ValueRefinement } from "../../../../model/selecting/browse/ValueRefinement";
+import { AppliedFilterData } from "../../../../model/selecting/browse/props_data/AppliedFilterData";
 import { FilterPartSizeData } from "../../../../model/selecting/browse/props_data/FilterPartSizeData";
 import { FilterPartSizeCallback } from "../callback/FilterPartSizeCallback";
-import { FilterPartSizeResponse } from "../../../../model/api/response/styling/browse/FilterPartSizeResponse";
-import { AppliedFilterData } from "../../../../model/selecting/browse/props_data/AppliedFilterData";
-import { ValueRefinement } from "../../../../model/selecting/browse/ValueRefinement";
 
 export interface PartSizeRefinementHandler {
   partSizeCallback: (
     choice: FilterPartSizeResponse,
-    currentValues: ValueRefinement[]
+    currentValues: ValueRefinement[],
   ) => FilterPartSizeCallback;
   partSizeData: (
     choice: FilterPartSizeResponse,
-    currentValues: ValueRefinement[]
+    currentValues: ValueRefinement[],
   ) => FilterPartSizeData;
   appliedFilters: (
     choice: FilterPartSizeResponse,
-    currentValues: ValueRefinement[]
+    currentValues: ValueRefinement[],
   ) => AppliedFilterData[];
   deleteFilter: (currentValues: ValueRefinement[], index: number) => void;
   resetPresetIndex: () => void;
 }
 
 export const usePartSizeRefinementHandler = (
-  onChange: (newValues: ValueRefinement[]) => void
+  onChange: (newValues: ValueRefinement[]) => void,
 ): PartSizeRefinementHandler => {
-  const [selectedPresetIndex, setSelectedPresetIndex] = useState<number | null>(
-    null
-  );
+  const [selectedPresetIndex, setSelectedPresetIndex] = useState<number | null>(null);
   const partSizeCallback = (
     choice: FilterPartSizeResponse,
-    currentValues: ValueRefinement[]
+    currentValues: ValueRefinement[],
   ): FilterPartSizeCallback => {
     return {
       onPresetChanged: (index: number) => {
@@ -40,7 +38,7 @@ export const usePartSizeRefinementHandler = (
       filterSliderArrayCallback: {
         onChange: (index: number, value: number[]) => {
           const currentIndex = currentValues.findIndex(
-            (filter) => filter.id === choice.ranges[index].id
+            (filter) => filter.id === choice.ranges[index].id,
           );
           const newPartSizes = [...currentValues];
           const newValue = {
@@ -61,7 +59,7 @@ export const usePartSizeRefinementHandler = (
 
   const partSizeData = (
     choice: FilterPartSizeResponse,
-    currentValues: ValueRefinement[]
+    currentValues: ValueRefinement[],
   ): FilterPartSizeData => {
     return {
       selectedPresetIndex: selectedPresetIndex,
@@ -74,10 +72,8 @@ export const usePartSizeRefinementHandler = (
           name: filter.name,
           range: [filter.min, filter.max],
           selectedValue: [
-            currentValues.find((value) => value.id === filter.id)?.min ??
-              filter.min,
-            currentValues.find((value) => value.id === filter.id)?.max ??
-              filter.max,
+            currentValues.find((value) => value.id === filter.id)?.min ?? filter.min,
+            currentValues.find((value) => value.id === filter.id)?.max ?? filter.max,
           ],
         };
       }),
@@ -86,10 +82,10 @@ export const usePartSizeRefinementHandler = (
 
   const appliedFilters = (
     choice: FilterPartSizeResponse,
-    currentValues: ValueRefinement[]
+    currentValues: ValueRefinement[],
   ): AppliedFilterData[] => {
     return currentValues.map((valueRefinement) => {
-      let filter = choice.ranges.find((row) => row.id === valueRefinement.id);
+      const filter = choice.ranges.find((row) => row.id === valueRefinement.id);
       return {
         name: `${filter?.name} ${valueRefinement.min}~${valueRefinement.max}`,
       };
@@ -97,7 +93,7 @@ export const usePartSizeRefinementHandler = (
   };
 
   const deleteFilter = (currentValues: ValueRefinement[], index: number) => {
-    let newPartSizes = [...currentValues];
+    const newPartSizes = [...currentValues];
     newPartSizes.splice(index, 1);
     onChange(newPartSizes);
   };

--- a/src/components/selecting/browse/handler/UsePatternRefinementHandler.ts
+++ b/src/components/selecting/browse/handler/UsePatternRefinementHandler.ts
@@ -6,21 +6,15 @@ import { FilterMediaArrayCallback } from "../callback/FilterMediaArrayCallback";
 export interface PatternRefinementHandler {
   patternCallback: (
     choice: FilterMediaResponse[],
-    currentIds: number[]
+    currentIds: number[],
   ) => FilterMediaArrayCallback;
-  patternData: (
-    choice: FilterMediaResponse[],
-    currentIds: number[]
-  ) => FilterMediaData[];
-  appliedFilters: (
-    choice: FilterMediaResponse[],
-    currentIds: number[]
-  ) => AppliedFilterData[];
+  patternData: (choice: FilterMediaResponse[], currentIds: number[]) => FilterMediaData[];
+  appliedFilters: (choice: FilterMediaResponse[], currentIds: number[]) => AppliedFilterData[];
   deleteFilter: (currentIds: number[], index: number) => void;
 }
 
 export const usePatternRefinementHandler = (
-  onChange: (newIds: number[]) => void
+  onChange: (newIds: number[]) => void,
 ): PatternRefinementHandler => {
   const newFilterArray = (id: number, currentArray: number[]): number[] => {
     const currentIndex = currentArray.indexOf(id);
@@ -35,7 +29,7 @@ export const usePatternRefinementHandler = (
 
   const patternCallback = (
     choice: FilterMediaResponse[],
-    currentIds: number[]
+    currentIds: number[],
   ): FilterMediaArrayCallback => {
     return {
       onClick: (index: number) => {
@@ -45,10 +39,7 @@ export const usePatternRefinementHandler = (
     };
   };
 
-  const patternData = (
-    choice: FilterMediaResponse[],
-    currentIds: number[]
-  ): FilterMediaData[] => {
+  const patternData = (choice: FilterMediaResponse[], currentIds: number[]): FilterMediaData[] => {
     return choice.map((filter) => {
       return {
         name: filter.name,
@@ -60,15 +51,16 @@ export const usePatternRefinementHandler = (
 
   const appliedFilters = (
     choice: FilterMediaResponse[],
-    currentIds: number[]
+    currentIds: number[],
   ): AppliedFilterData[] => {
     return currentIds.map((currentId) => {
-      return { name: choice.find((filter) => filter.id === currentId)!!.name };
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return { name: choice.find((filter) => filter.id === currentId)!.name };
     });
   };
 
   const deleteFilter = (currentIds: number[], index: number) => {
-    let newPatterns = [...currentIds];
+    const newPatterns = [...currentIds];
     newPatterns.splice(index, 1);
     onChange(newPatterns);
   };

--- a/src/components/selecting/browse/handler/UseSizeRefinementHandler.ts
+++ b/src/components/selecting/browse/handler/UseSizeRefinementHandler.ts
@@ -4,23 +4,14 @@ import { FilterSizeData } from "../../../../model/selecting/browse/props_data/Fi
 import { FilterSizeArrayCallback } from "../callback/FilterSizeArrayCallback";
 
 export interface SizeRefinementHandler {
-  sizeCallback: (
-    choice: FilterResponse[],
-    currentIds: number[]
-  ) => FilterSizeArrayCallback;
-  sizeData: (
-    choice: FilterResponse[],
-    currentIds: number[]
-  ) => FilterSizeData[];
-  appliedFilters: (
-    choice: FilterResponse[],
-    currentIds: number[]
-  ) => AppliedFilterData[];
+  sizeCallback: (choice: FilterResponse[], currentIds: number[]) => FilterSizeArrayCallback;
+  sizeData: (choice: FilterResponse[], currentIds: number[]) => FilterSizeData[];
+  appliedFilters: (choice: FilterResponse[], currentIds: number[]) => AppliedFilterData[];
   deleteFilter: (currentIds: number[], index: number) => void;
 }
 
 export const useSizeRefinementHandler = (
-  onChange: (newIds: number[]) => void
+  onChange: (newIds: number[]) => void,
 ): SizeRefinementHandler => {
   const newFilterArray = (id: number, currentArray: number[]): number[] => {
     const currentIndex = currentArray.indexOf(id);
@@ -35,7 +26,7 @@ export const useSizeRefinementHandler = (
 
   const sizeCallback = (
     choice: FilterResponse[],
-    currentIds: number[]
+    currentIds: number[],
   ): FilterSizeArrayCallback => {
     return {
       onClick: (index: number) => {
@@ -45,10 +36,7 @@ export const useSizeRefinementHandler = (
     };
   };
 
-  const sizeData = (
-    choice: FilterResponse[],
-    currentIds: number[]
-  ): FilterSizeData[] => {
+  const sizeData = (choice: FilterResponse[], currentIds: number[]): FilterSizeData[] => {
     return choice.map((filter) => {
       return {
         name: filter.name,
@@ -57,10 +45,7 @@ export const useSizeRefinementHandler = (
     });
   };
 
-  const appliedFilters = (
-    choice: FilterResponse[],
-    currentIds: number[]
-  ): AppliedFilterData[] => {
+  const appliedFilters = (choice: FilterResponse[], currentIds: number[]): AppliedFilterData[] => {
     return currentIds.map((currentId) => {
       return {
         name: choice.find((filter) => filter.id === currentId)?.name ?? "",
@@ -69,7 +54,7 @@ export const useSizeRefinementHandler = (
   };
 
   const deleteFilter = (currentIds: number[], index: number) => {
-    let newSizes = [...currentIds];
+    const newSizes = [...currentIds];
     newSizes.splice(index, 1);
     onChange(newSizes);
   };

--- a/src/components/selecting/browse/style/UseFilterSliderArrayStyle.ts
+++ b/src/components/selecting/browse/style/UseFilterSliderArrayStyle.ts
@@ -1,12 +1,10 @@
-import { Theme } from "@mui/material/styles";
-
 import createStyles from "@mui/styles/createStyles";
 import makeStyles from "@mui/styles/makeStyles";
 
-export const useFilterSliderArrayStyle = makeStyles((theme: Theme) =>
+export const useFilterSliderArrayStyle = makeStyles(() =>
   createStyles({
     filterSliderList: {
       width: "100%",
     },
-  })
+  }),
 );

--- a/src/components/selecting/browse/style/UseValidationDialogStyle.ts
+++ b/src/components/selecting/browse/style/UseValidationDialogStyle.ts
@@ -1,10 +1,9 @@
 import { orange, red } from "@mui/material/colors";
-import { Theme } from "@mui/material/styles";
 
 import createStyles from "@mui/styles/createStyles";
 import makeStyles from "@mui/styles/makeStyles";
 
-export const useValidationDialogStyle = makeStyles((theme: Theme) =>
+export const useValidationDialogStyle = makeStyles(() =>
   createStyles({
     error: {
       backgroundColor: red[500],
@@ -12,5 +11,5 @@ export const useValidationDialogStyle = makeStyles((theme: Theme) =>
     warning: {
       backgroundColor: orange[500],
     },
-  })
+  }),
 );

--- a/src/components/simplifiedHearing/SimplifiedHearing.tsx
+++ b/src/components/simplifiedHearing/SimplifiedHearing.tsx
@@ -6,14 +6,10 @@ import { SimplifiedHearingsShowResponse } from "../../model/api/response/styling
 type TProps = {
   data: SimplifiedHearingsShowResponse;
   coordinateId: number;
-  onUpdateComplete: () => Promise<any>;
+  onUpdateComplete: () => Promise<unknown>;
 };
 
-export const SimplifiedHearing = ({
-  data,
-  coordinateId,
-  onUpdateComplete,
-}: TProps) => {
+export const SimplifiedHearing = ({ data, coordinateId, onUpdateComplete }: TProps) => {
   const [target, setTarget] = useState<string>(data.target ?? "");
   const [scene, setScene] = useState<string>(data.scene ?? "");
   const [impression, setImpression] = useState<string>(data.impression ?? "");
@@ -97,7 +93,7 @@ export const SimplifiedHearing = ({
                 onSettled: () => {
                   setIsSnackBarOpen(true);
                 },
-              }
+              },
             );
           }}
           style={{ width: "100%" }}

--- a/src/hooks/api/UseBrowsesDetail.ts
+++ b/src/hooks/api/UseBrowsesDetail.ts
@@ -22,12 +22,13 @@ export const useBrowsesDetail = ({
   refinement,
 }: TBrowsesDetailArg): BrowsesDetail => {
   const params = (): GetDetailParams => {
-    let filterParams: GetDetailFilterParams = {
+    const filterParams: GetDetailFilterParams = {
       size: refinement.sizeIds,
       partSize: refinement.partSizes,
       ng: refinement.ngIds,
       ranks: refinement.rank,
     };
+
     if (refinement.itemId) filterParams.itemId = refinement.itemId;
 
     return {

--- a/src/hooks/api/UseBrowsesIndex.ts
+++ b/src/hooks/api/UseBrowsesIndex.ts
@@ -1,8 +1,4 @@
-import {
-  QueryObserverResult,
-  RefetchOptions,
-  RefetchQueryFilters,
-} from "react-query";
+import { QueryObserverResult, RefetchOptions, RefetchQueryFilters } from "react-query";
 import { GetIndexFilterParams } from "../../model/api/request/styling/browse/GetIndexFilterParams";
 import { GetIndexParams } from "../../model/api/request/styling/browse/GetIndexParams";
 import { BrowseIndexResponse } from "../../model/api/response/styling/browse/BrowseIndexResponse";
@@ -20,12 +16,9 @@ type BrowsesIndex = {
 
 type TBrowsesIndexArg = { refinement: Refinement; chartId?: number };
 
-export const useBrowsesIndex = ({
-  refinement,
-  chartId,
-}: TBrowsesIndexArg): BrowsesIndex => {
+export const useBrowsesIndex = ({ refinement, chartId }: TBrowsesIndexArg): BrowsesIndex => {
   const params = (): GetIndexParams => {
-    var filterParams: GetIndexFilterParams = {
+    const filterParams: GetIndexFilterParams = {
       smallCategory: refinement.smallCategoryIds,
       size: refinement.sizeIds,
       partSize: refinement.partSizes,
@@ -41,10 +34,8 @@ export const useBrowsesIndex = ({
       option: refinement.optionIds,
       rank: refinement.rank,
     };
-    if (refinement.mediumCategoryId)
-      filterParams.mediumCategory = refinement.mediumCategoryId;
-    if (refinement.largeCategoryId)
-      filterParams.largeCategory = refinement.largeCategoryId;
+    if (refinement.mediumCategoryId) filterParams.mediumCategory = refinement.mediumCategoryId;
+    if (refinement.largeCategoryId) filterParams.largeCategory = refinement.largeCategoryId;
     if (refinement.itemId) filterParams.itemId = refinement.itemId;
 
     return {
@@ -55,12 +46,11 @@ export const useBrowsesIndex = ({
     };
   };
 
-  const { data, error, refetch, isFetching } =
-    useGetRequest<BrowseIndexResponse>(
-      "styling/browses",
-      params(),
-      `styling/browses${JSON.stringify(params())}`,
-    );
+  const { data, error, refetch, isFetching } = useGetRequest<BrowseIndexResponse>(
+    "styling/browses",
+    params(),
+    `styling/browses${JSON.stringify(params())}`,
+  );
 
   return {
     data,

--- a/src/hooks/api/UseCoordinateDescriptionsUpdate.ts
+++ b/src/hooks/api/UseCoordinateDescriptionsUpdate.ts
@@ -4,7 +4,7 @@ import { usePatchRequest } from "./UsePatchRequest";
 
 type CoordinateDescriptionsUpdate = {
   readonly mutate: UseMutateFunction<
-    AxiosResponse<any, any>,
+    AxiosResponse<unknown, unknown>,
     Error,
     TCoordinateDescriptionsUpdateParams | undefined,
     unknown
@@ -23,10 +23,9 @@ type TCoordinateDescriptionsUpdateArgs = {
 export const useCoordinateDescriptionsUpdate = ({
   coordinateId,
 }: TCoordinateDescriptionsUpdateArgs): CoordinateDescriptionsUpdate => {
-  const { mutate, isLoading } = usePatchRequest<
-    TCoordinateDescriptionsUpdateParams,
-    Error
-  >(`styling/coordinates/${coordinateId}/coordinate_description`);
+  const { mutate, isLoading } = usePatchRequest<TCoordinateDescriptionsUpdateParams, Error>(
+    `styling/coordinates/${coordinateId}/coordinate_description`,
+  );
 
   return { mutate, isLoading };
 };

--- a/src/hooks/api/UseCoordinateFootwearsUpdate.ts
+++ b/src/hooks/api/UseCoordinateFootwearsUpdate.ts
@@ -6,7 +6,7 @@ import { usePatchRequest } from "./UsePatchRequest";
 
 type CoordinateFootwearsUpdate = {
   readonly mutate: UseMutateFunction<
-    AxiosResponse<any, any>,
+    AxiosResponse<unknown, unknown>,
     Error,
     TCoordinateFootwearsUpdateParams | undefined
   >;
@@ -19,10 +19,9 @@ type TCoordinateFootwearsUpdateParams = {
 
 export const useCoordinateFootwearsUpdate = (): CoordinateFootwearsUpdate => {
   const coordinateId = useContextDefinedState(CoordinateIdContext);
-  const { mutate, isLoading } = usePatchRequest<
-    TCoordinateFootwearsUpdateParams,
-    Error
-  >(`styling/coordinates/${coordinateId}/coordinate_footwear`);
+  const { mutate, isLoading } = usePatchRequest<TCoordinateFootwearsUpdateParams, Error>(
+    `styling/coordinates/${coordinateId}/coordinate_footwear`,
+  );
 
   return { mutate, isLoading };
 };

--- a/src/hooks/api/UseCoordinateHearingStatusShow.ts
+++ b/src/hooks/api/UseCoordinateHearingStatusShow.ts
@@ -12,9 +12,9 @@ type TArgs = {
 };
 
 export const useCoordinateHearingStatusShow = ({ coordinateId }: TArgs) => {
-  const { data, error } = useGetRequest<
-    TCoordinateHearingStatusShowResponse | {}
-  >(`styling/coordinates/${coordinateId}/coordinate_hearing_status`);
+  const { data, error } = useGetRequest<TCoordinateHearingStatusShowResponse | object>(
+    `styling/coordinates/${coordinateId}/coordinate_hearing_status`,
+  );
 
   return { data, error };
 };

--- a/src/hooks/api/UseCoordinateItemsUpdate.ts
+++ b/src/hooks/api/UseCoordinateItemsUpdate.ts
@@ -4,7 +4,7 @@ import { usePatchRequest } from "./UsePatchRequest";
 
 type TCoordinateitemsUpdate = {
   readonly mutate: UseMutateFunction<
-    AxiosResponse<any, any>,
+    AxiosResponse<unknown, unknown>,
     Error,
     TCoordinateItemsUpdateParams | undefined
   >;
@@ -22,10 +22,9 @@ type TCoordinateItemsUpdateArg = {
 export const useCoordinateItemsUpdate = ({
   coordinateItemId,
 }: TCoordinateItemsUpdateArg): TCoordinateitemsUpdate => {
-  const { mutate, isLoading } = usePatchRequest<
-    TCoordinateItemsUpdateParams,
-    Error
-  >(`styling/coordinate_items/${coordinateItemId}`);
+  const { mutate, isLoading } = usePatchRequest<TCoordinateItemsUpdateParams, Error>(
+    `styling/coordinate_items/${coordinateItemId}`,
+  );
 
   return { mutate, isLoading };
 };

--- a/src/hooks/api/UseCoordinateMemosUpdate.ts
+++ b/src/hooks/api/UseCoordinateMemosUpdate.ts
@@ -4,7 +4,7 @@ import { usePatchRequest } from "./UsePatchRequest";
 
 type CoordinateMemosUpdate = {
   readonly mutate: UseMutateFunction<
-    AxiosResponse<any, any>,
+    AxiosResponse<unknown, unknown>,
     Error,
     TCoordinateMemosUpdateParams | undefined
   >;
@@ -22,10 +22,9 @@ type TCoordinateMemosUpdateArg = {
 export const useCoordinateMemosUpdate = ({
   coordinateId,
 }: TCoordinateMemosUpdateArg): CoordinateMemosUpdate => {
-  const { mutate, isLoading } = usePatchRequest<
-    TCoordinateMemosUpdateParams,
-    Error
-  >(`styling/coordinates/${coordinateId}/coordinate_memos`);
+  const { mutate, isLoading } = usePatchRequest<TCoordinateMemosUpdateParams, Error>(
+    `styling/coordinates/${coordinateId}/coordinate_memos`,
+  );
 
   return { mutate, isLoading };
 };

--- a/src/hooks/api/UseCoordinatePatternsBulkUpdate.ts
+++ b/src/hooks/api/UseCoordinatePatternsBulkUpdate.ts
@@ -17,7 +17,7 @@ export const useCoordinatePatternsBulkUpdate = ({
   coordinateId,
 }: TArrangesCreateOutfitsArg): {
   mutate: UseMutateFunction<
-    AxiosResponse<any, any>,
+    AxiosResponse<unknown, unknown>,
     unknown,
     PostCreateOutfitParams | undefined,
     unknown

--- a/src/hooks/api/UseCoordinateStylistCommentsUpdate.ts
+++ b/src/hooks/api/UseCoordinateStylistCommentsUpdate.ts
@@ -4,7 +4,7 @@ import { usePatchRequest } from "./UsePatchRequest";
 
 type CoordinateStylistCommentsUpdate = {
   readonly mutate: UseMutateFunction<
-    AxiosResponse<any, any>,
+    AxiosResponse<unknown, unknown>,
     Error,
     TCoordinateStylistCommentsUpdateParams | undefined,
     unknown
@@ -23,10 +23,9 @@ type TCoordinateStylistCommentsUpdateArgs = {
 export const useCoordinateStylistCommentsUpdate = ({
   coordinateId,
 }: TCoordinateStylistCommentsUpdateArgs): CoordinateStylistCommentsUpdate => {
-  const { mutate, isLoading } = usePatchRequest<
-    TCoordinateStylistCommentsUpdateParams,
-    Error
-  >(`styling/coordinates/${coordinateId}/coordinate_stylist_comment`);
+  const { mutate, isLoading } = usePatchRequest<TCoordinateStylistCommentsUpdateParams, Error>(
+    `styling/coordinates/${coordinateId}/coordinate_stylist_comment`,
+  );
 
   return { mutate, isLoading };
 };

--- a/src/hooks/api/UseCoordinateTopsRatiosUpdate.ts
+++ b/src/hooks/api/UseCoordinateTopsRatiosUpdate.ts
@@ -6,7 +6,7 @@ import { usePatchRequest } from "./UsePatchRequest";
 
 type CoordinateTopsRatiosUpdate = {
   readonly mutate: UseMutateFunction<
-    AxiosResponse<any, any>,
+    AxiosResponse,
     Error,
     TCoordinateTopsRatiosUpdateParams | undefined
   >;
@@ -31,15 +31,15 @@ export const useCoordinateTopsRatiosUpdate = ({
   isJacketRequested,
 }: TCoordinateTopsRatiosUpdateArg): CoordinateTopsRatiosUpdate => {
   const adminShow = useContextDefinedState(AdminShowContext);
-  const { mutate, isLoading } = usePatchRequest<
-    TCoordinateTopsRatiosUpdateParams,
-    Error
-  >(`styling/coordinates/${coordinateId}/coordinate_tops_ratios`, {
-    longSleeveNum,
-    shortSleeveNum,
-    isJacketRequested,
-    adminId: adminShow.id,
-  });
+  const { mutate, isLoading } = usePatchRequest<TCoordinateTopsRatiosUpdateParams, Error>(
+    `styling/coordinates/${coordinateId}/coordinate_tops_ratios`,
+    {
+      longSleeveNum,
+      shortSleeveNum,
+      isJacketRequested,
+      adminId: adminShow.id,
+    },
+  );
 
   return { mutate, isLoading };
 };

--- a/src/hooks/api/UseDeleteRequest.ts
+++ b/src/hooks/api/UseDeleteRequest.ts
@@ -8,8 +8,9 @@ export const useDeleteRequest = <T>(
   afterMutation: {
     onSuccess: () => Promise<unknown> | void;
     onError: () => Promise<unknown> | void;
-  } = { onSuccess: () => {}, onError: () => {} },
+  } = { onSuccess: () => undefined, onError: () => undefined },
 ) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { mutate, error, isLoading } = useMutation<any, Error, number | string>(
     path,
     (id) =>

--- a/src/hooks/api/UseGetRequest.ts
+++ b/src/hooks/api/UseGetRequest.ts
@@ -1,18 +1,13 @@
 import qs from "qs";
-import {
-  QueryObserverResult,
-  RefetchOptions,
-  RefetchQueryFilters,
-  useQuery,
-} from "react-query";
+import { QueryObserverResult, RefetchOptions, RefetchQueryFilters, useQuery } from "react-query";
 import { baseUrl } from "../../model/api/shared/BaseUrl";
 import { axiosClient } from "./../../model/api/shared/AxiosClient";
 
 export const useGetRequest = <T>(
   path: string,
-  params?: {},
+  params?: object,
   queryKey?: string,
-  isEnabled: boolean = true,
+  isEnabled = true,
 ): {
   data?: T;
   error: Error | null;
@@ -28,8 +23,7 @@ export const useGetRequest = <T>(
         .get(`${baseUrl()}/${path}`, {
           params,
           paramsSerializer: {
-            serialize: (params) =>
-              qs.stringify(params, { arrayFormat: "brackets", encode: false }),
+            serialize: (params) => qs.stringify(params, { arrayFormat: "brackets", encode: false }),
           },
         })
         .then((r) => r.data),

--- a/src/hooks/api/UseKartesUpdate.ts
+++ b/src/hooks/api/UseKartesUpdate.ts
@@ -5,7 +5,7 @@ import { usePatchRequest } from "./UsePatchRequest";
 
 type TKartesUpdate = {
   readonly mutate: UseMutateFunction<
-    AxiosResponse<any, any>,
+    AxiosResponse,
     unknown,
     TKartesUpdateParams | undefined,
     unknown
@@ -21,12 +21,9 @@ type TKartesUpdateArg = {
   chartId: number;
 };
 
-export const useKartesUpdate = ({
-  chartId,
-}: TKartesUpdateArg): TKartesUpdate => {
-  const { mutate, isLoading } = usePatchRequest<
-    TKartesUpdateParams,
-    AxiosError<ErrorResponse>
-  >(`styling/kartes/${chartId}`);
+export const useKartesUpdate = ({ chartId }: TKartesUpdateArg): TKartesUpdate => {
+  const { mutate, isLoading } = usePatchRequest<TKartesUpdateParams, AxiosError<ErrorResponse>>(
+    `styling/kartes/${chartId}`,
+  );
   return { mutate, isLoading };
 };

--- a/src/hooks/api/UseMemberPatchRequest.ts
+++ b/src/hooks/api/UseMemberPatchRequest.ts
@@ -8,20 +8,16 @@ type TMemberPatchRequestArg<T> = {
   params?: T;
 };
 
-export const useMemberPatchRequest = <TParams = {}, TError = unknown>({
+export const useMemberPatchRequest = <TParams = object, TError = unknown>({
   path,
   memberId,
   params,
 }: TMemberPatchRequestArg<TParams>) => {
   const queryClient = useQueryClient();
 
-  return usePatchRequest<TParams, TError>(
-    `styling/members/${memberId}/${path}`,
-    params,
-    {
-      onSuccess: () => {
-        queryClient.invalidateQueries(`member/${path}`);
-      },
+  return usePatchRequest<TParams, TError>(`styling/members/${memberId}/${path}`, params, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(`member/${path}`);
     },
-  );
+  });
 };

--- a/src/hooks/api/UseNgsUpdate.ts
+++ b/src/hooks/api/UseNgsUpdate.ts
@@ -7,7 +7,7 @@ import { usePatchRequest } from "./UsePatchRequest";
 
 type TNgUpdate = {
   readonly mutate: UseMutateFunction<
-    AxiosResponse<any, any>,
+    AxiosResponse,
     unknown,
     (NgCreateRequest & { readonly memberId: number }) | undefined,
     unknown

--- a/src/hooks/api/UsePatchRequest.ts
+++ b/src/hooks/api/UsePatchRequest.ts
@@ -3,13 +3,14 @@ import { useMutation } from "react-query";
 import { axiosClient } from "./../../model/api/shared/AxiosClient";
 import { baseUrl } from "./../../model/api/shared/BaseUrl";
 
-export const usePatchRequest = <TParams = {}, TError = any>(
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const usePatchRequest = <TParams = object, TError = any>(
   path: string,
   params?: TParams,
   afterMutation: {
     onSuccess?: () => Promise<unknown> | void;
     onError?: () => Promise<TError> | void;
-  } = { onSuccess: () => {}, onError: () => {} },
+  } = { onSuccess: () => undefined, onError: () => undefined },
 ) => {
   const { mutate, error, isLoading, isSuccess } = useMutation<
     AxiosResponse,
@@ -17,8 +18,7 @@ export const usePatchRequest = <TParams = {}, TError = any>(
     TParams | undefined
   >(
     path,
-    (lateParams?: TParams) =>
-      axiosClient.patch(`${baseUrl()}/${path}`, lateParams ?? params),
+    (lateParams?: TParams) => axiosClient.patch(`${baseUrl()}/${path}`, lateParams ?? params),
     afterMutation,
   );
 

--- a/src/hooks/api/UsePostRequest.ts
+++ b/src/hooks/api/UsePostRequest.ts
@@ -3,13 +3,14 @@ import { useMutation } from "react-query";
 import { axiosClient } from "./../../model/api/shared/AxiosClient";
 import { baseUrl } from "./../../model/api/shared/BaseUrl";
 
-export const usePostRequest = <TParams = {}, TError = any>(
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const usePostRequest = <TParams = object, TError = any>(
   path: string,
   params?: TParams,
   afterMutation: {
     onSuccess?: () => Promise<unknown> | void;
     onError?: () => Promise<TError> | void;
-  } = { onSuccess: () => {}, onError: () => {} },
+  } = { onSuccess: () => undefined, onError: () => undefined },
 ) => {
   const { mutate, error, isLoading, isSuccess, isIdle, reset } = useMutation<
     AxiosResponse,
@@ -17,8 +18,7 @@ export const usePostRequest = <TParams = {}, TError = any>(
     TParams | undefined
   >(
     path,
-    (lateParams?: TParams) =>
-      axiosClient.post(`${baseUrl()}/${path}`, lateParams ?? params),
+    (lateParams?: TParams) => axiosClient.post(`${baseUrl()}/${path}`, lateParams ?? params),
     afterMutation,
   );
 

--- a/src/hooks/api/UseSimplifiedHearingsUpdate.ts
+++ b/src/hooks/api/UseSimplifiedHearingsUpdate.ts
@@ -4,7 +4,7 @@ import { usePatchRequest } from "./UsePatchRequest";
 
 type TSimplifiedHearingsUpdate = {
   readonly mutate: UseMutateFunction<
-    AxiosResponse<any, any>,
+    AxiosResponse,
     Error,
     TSimplifiedHearingsUpdateParams | undefined,
     unknown
@@ -25,10 +25,9 @@ type TSimplifiedHearingsUpdateArgs = {
 export const useSimplifiedHearingsUpdate = ({
   coordinateId,
 }: TSimplifiedHearingsUpdateArgs): TSimplifiedHearingsUpdate => {
-  const { mutate, isLoading } = usePatchRequest<
-    TSimplifiedHearingsUpdateParams,
-    Error
-  >(`styling/coordinates/${coordinateId}/simplified_hearing`);
+  const { mutate, isLoading } = usePatchRequest<TSimplifiedHearingsUpdateParams, Error>(
+    `styling/coordinates/${coordinateId}/simplified_hearing`,
+  );
 
   return { mutate, isLoading };
 };

--- a/src/service/shared/alertClosedWindow.ts
+++ b/src/service/shared/alertClosedWindow.ts
@@ -8,6 +8,7 @@ export const alertClosedWindow = (isClosable: boolean) => {
   };
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const onUnload = (e: any) => {
   e.preventDefault();
   e.returnValue = "";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1323,7 +1323,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz#d0fce5d07b0620caa282b5131c297bb60f9d87e6"
   integrity sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==
 
-"@eslint-community/eslint-utils@^4.2.0":
+"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
   integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
@@ -1334,6 +1334,11 @@
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.1.tgz#cdd35dce4fa1a89a4fd42b1599eb35b3af408884"
   integrity sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==
+
+"@eslint-community/regexpp@^4.5.1":
+  version "4.10.0"
+  resolved "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz#548f6de556857c8bb73bbee70c35dc82a2e74d63"
+  integrity sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==
 
 "@eslint/eslintrc@^2.0.2":
   version "2.0.2"
@@ -2088,6 +2093,18 @@
   dependencies:
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
+
+"@kiizan_kiizan/eslint-config@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.npmjs.org/@kiizan_kiizan/eslint-config/-/eslint-config-0.0.7.tgz#68a3f66b1bd29479066ae02ef7d7ee86574f4d21"
+  integrity sha512-AwAoZ7QsAaB4QTaeJ8u+9884wDgbMrM+ICepaUA8tOVf+vDFYpoLDELmsfpaEm6fTpvTW2+/OcN4d1YmRNkIzw==
+  dependencies:
+    "@typescript-eslint/eslint-plugin" "^6.9.0"
+
+"@kiizan_kiizan/prettier-config@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.npmjs.org/@kiizan_kiizan/prettier-config/-/prettier-config-0.0.5.tgz#1c0a78dc0cad1535caf6f8b8ced0ea73f05c1862"
+  integrity sha512-en7v6a2ptiBL6lsJvdurk6+ybB/zNHzqHJexTizKj+/RoXK0ERCfYlHRe+1Z/j6M0QdNf6Wyi6UmbPy78wRzTQ==
 
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"
@@ -2907,6 +2924,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
+"@types/json-schema@^7.0.12":
+  version "7.0.14"
+  resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.14.tgz#74a97a5573980802f32c8e47b663530ab3b6b7d1"
+  integrity sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -3045,6 +3067,11 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
 
+"@types/semver@^7.5.0":
+  version "7.5.4"
+  resolved "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz#0a41252ad431c473158b22f9bfb9a63df7541cff"
+  integrity sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==
+
 "@types/send@*":
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/@types/send/-/send-0.17.1.tgz#ed4932b8a2a805f1fe362a70f4e62d0ac994e301"
@@ -3127,6 +3154,23 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
+"@typescript-eslint/eslint-plugin@^6.9.0":
+  version "6.9.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.9.0.tgz#fdb6f3821c0167e3356e9d89c80e8230b2e401f4"
+  integrity sha512-lgX7F0azQwRPB7t7WAyeHWVfW1YJ9NIgd9mvGhfQpRY56X6AVf8mwM8Wol+0z4liE7XX3QOt8MN1rUKCfSjRIA==
+  dependencies:
+    "@eslint-community/regexpp" "^4.5.1"
+    "@typescript-eslint/scope-manager" "6.9.0"
+    "@typescript-eslint/type-utils" "6.9.0"
+    "@typescript-eslint/utils" "6.9.0"
+    "@typescript-eslint/visitor-keys" "6.9.0"
+    debug "^4.3.4"
+    graphemer "^1.4.0"
+    ignore "^5.2.4"
+    natural-compare "^1.4.0"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
+
 "@typescript-eslint/experimental-utils@^5.0.0":
   version "5.59.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.59.2.tgz#c2785247c4c8929cb6946e46280ea44f54d9cf79"
@@ -3152,6 +3196,14 @@
     "@typescript-eslint/types" "5.59.2"
     "@typescript-eslint/visitor-keys" "5.59.2"
 
+"@typescript-eslint/scope-manager@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.0.tgz#2626e9a7fe0e004c3e25f3b986c75f584431134e"
+  integrity sha512-1R8A9Mc39n4pCCz9o79qRO31HGNDvC7UhPhv26TovDsWPBDx+Sg3rOZdCELIA3ZmNoWAuxaMOT7aWtGRSYkQxw==
+  dependencies:
+    "@typescript-eslint/types" "6.9.0"
+    "@typescript-eslint/visitor-keys" "6.9.0"
+
 "@typescript-eslint/type-utils@5.59.2":
   version "5.59.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.59.2.tgz#0729c237503604cd9a7084b5af04c496c9a4cdcf"
@@ -3162,10 +3214,25 @@
     debug "^4.3.4"
     tsutils "^3.21.0"
 
+"@typescript-eslint/type-utils@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.9.0.tgz#23923c8c9677c2ad41457cf8e10a5f2946be1b04"
+  integrity sha512-XXeahmfbpuhVbhSOROIzJ+b13krFmgtc4GlEuu1WBT+RpyGPIA4Y/eGnXzjbDj5gZLzpAXO/sj+IF/x2GtTMjQ==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "6.9.0"
+    "@typescript-eslint/utils" "6.9.0"
+    debug "^4.3.4"
+    ts-api-utils "^1.0.1"
+
 "@typescript-eslint/types@5.59.2":
   version "5.59.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.2.tgz#b511d2b9847fe277c5cb002a2318bd329ef4f655"
   integrity sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==
+
+"@typescript-eslint/types@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.0.tgz#86a0cbe7ac46c0761429f928467ff3d92f841098"
+  integrity sha512-+KB0lbkpxBkBSiVCuQvduqMJy+I1FyDbdwSpM3IoBS7APl4Bu15lStPjgBIdykdRqQNYqYNMa8Kuidax6phaEw==
 
 "@typescript-eslint/typescript-estree@5.59.2":
   version "5.59.2"
@@ -3179,6 +3246,19 @@
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.0.tgz#d0601b245be873d8fe49f3737f93f8662c8693d4"
+  integrity sha512-NJM2BnJFZBEAbCfBP00zONKXvMqihZCrmwCaik0UhLr0vAgb6oguXxLX1k00oQyD+vZZ+CJn3kocvv2yxm4awQ==
+  dependencies:
+    "@typescript-eslint/types" "6.9.0"
+    "@typescript-eslint/visitor-keys" "6.9.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
 
 "@typescript-eslint/utils@5.59.2", "@typescript-eslint/utils@^5.58.0":
   version "5.59.2"
@@ -3194,6 +3274,19 @@
     eslint-scope "^5.1.1"
     semver "^7.3.7"
 
+"@typescript-eslint/utils@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.9.0.tgz#5bdac8604fca4823f090e4268e681c84d3597c9f"
+  integrity sha512-5Wf+Jsqya7WcCO8me504FBigeQKVLAMPmUzYgDbWchINNh1KJbxCgVya3EQ2MjvJMVeXl3pofRmprqX6mfQkjQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.4.0"
+    "@types/json-schema" "^7.0.12"
+    "@types/semver" "^7.5.0"
+    "@typescript-eslint/scope-manager" "6.9.0"
+    "@typescript-eslint/types" "6.9.0"
+    "@typescript-eslint/typescript-estree" "6.9.0"
+    semver "^7.5.4"
+
 "@typescript-eslint/visitor-keys@5.59.2":
   version "5.59.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.2.tgz#37a419dc2723a3eacbf722512b86d6caf7d3b750"
@@ -3201,6 +3294,14 @@
   dependencies:
     "@typescript-eslint/types" "5.59.2"
     eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.0.tgz#cc69421c10c4ac997ed34f453027245988164e80"
+  integrity sha512-dGtAfqjV6RFOtIP8I0B4ZTBRrlTT8NHHlZZSchQx3qReaoDeXhYM++M4So2AgFK9ZB0emRPA6JI1HkafzA2Ibg==
+  dependencies:
+    "@typescript-eslint/types" "6.9.0"
+    eslint-visitor-keys "^3.4.1"
 
 "@webassemblyjs/ast@1.11.5", "@webassemblyjs/ast@^1.11.5":
   version "1.11.5"
@@ -5240,6 +5341,11 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz#c7f0f956124ce677047ddbc192a68f999454dedc"
   integrity sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==
 
+eslint-visitor-keys@^3.4.1:
+  version "3.4.3"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
+  integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
+
 eslint-webpack-plugin@^3.1.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/eslint-webpack-plugin/-/eslint-webpack-plugin-3.2.0.tgz#1978cdb9edc461e4b0195a20da950cf57988347c"
@@ -5911,6 +6017,11 @@ grapheme-splitter@^1.0.4:
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
+graphemer@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
+  integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
+
 gzip-size@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462"
@@ -6184,7 +6295,7 @@ identity-obj-proxy@^3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ignore@^5.2.0:
+ignore@^5.2.0, ignore@^5.2.4:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
@@ -9534,6 +9645,13 @@ semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"
@@ -10234,6 +10352,11 @@ tryer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
+
+ts-api-utils@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz#f12c1c781d04427313dbac808f453f050e54a331"
+  integrity sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==
 
 ts-interface-checker@^0.1.9:
   version "0.1.13"


### PR DESCRIPTION
## 要件

https://kiizan-kiizan.atlassian.net/browse/LEEAP-4975

https://github.com/KiizanKiizan/eslint-config-kiizan
https://github.com/KiizanKiizan/prettier-config-kiizan
をインストールした

## スクリーンショット

| before                                     | after                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="250" alt=""> | <img width="250" alt=""> |

## 関連タスク


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

新機能:
- `Chart`コンポーネントが更新され、`rentalStartedAt`の値に基づいて発送日を表示するようになりました。これにより、ユーザーはレンタル開始日を一目で確認できます。

修正:
- `rentalStartedAt`が存在しない場合、空文字列が表示されるように修正されました。これにより、不必要な混乱を避けることができます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->